### PR TITLE
story(issue-32): idl parse escaped identifiers

### DIFF
--- a/idl/parser.go
+++ b/idl/parser.go
@@ -319,11 +319,14 @@ func (p *parser) expectIdentifier() (Token, error) {
 			return Token{}, err
 		}
 
-		closeTok, err := p.expect(TokenSymbol)
+		closeTok, err, ok := p.read()
 		if err != nil {
+			return Token{}, err
+		}
+		if !ok {
 			return Token{}, UnterminatedEscapedIdentifierError{Pos: startPos}
 		}
-		if !bytes.Equal(closeTok.Value, []byte("`")) {
+		if closeTok.Type != TokenSymbol || !bytes.Equal(closeTok.Value, []byte("`")) {
 			return Token{}, UnterminatedEscapedIdentifierError{Pos: startPos}
 		}
 

--- a/idl/parser_test.go
+++ b/idl/parser_test.go
@@ -1963,6 +1963,11 @@ func TestParserEscapedIdentifierErrors(t *testing.T) {
 			src:         "schema int;\nenum Color { `null }",
 			expectedErr: UnterminatedEscapedIdentifierError{Pos: Pos{Line: 2, Column: 14}},
 		},
+		{
+			name:        "tokenizer error inside escaped identifier is preserved",
+			src:         "schema int;\nrecord `name$ { }",
+			expectedErr: UnexpectedCharacterError{Pos: Pos{Line: 2, Column: 14}, R: '$'},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Closes #32 