### PR TITLE
story(issue-91): schema-driven encoding/decoding of arbitrary Avro values

### DIFF
--- a/avro.go
+++ b/avro.go
@@ -29,6 +29,11 @@ type BinaryWriter struct {
 	offset int64
 }
 
+// NewBinaryWriter returns a BinaryWriter that writes to w.
+func NewBinaryWriter(w io.Writer) *BinaryWriter {
+	return &BinaryWriter{out: w}
+}
+
 // Offset returns the number of bytes successfully written so far.
 func (w *BinaryWriter) Offset() int64 {
 	return w.offset
@@ -182,6 +187,11 @@ func UnmarshalBinary(r io.Reader, v BinaryUnmarshaler) error {
 type BinaryReader struct {
 	in     io.Reader
 	offset int64
+}
+
+// NewBinaryReader returns a BinaryReader that reads from r.
+func NewBinaryReader(r io.Reader) *BinaryReader {
+	return &BinaryReader{in: r}
 }
 
 // Offset returns the number of bytes successfully consumed so far.

--- a/avro_test.go
+++ b/avro_test.go
@@ -16,26 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewBinaryWriter(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	w := NewBinaryWriter(&buf)
-	require.NoError(t, w.WriteString("hi"))
-	require.Equal(t, []byte{0x04, 'h', 'i'}, buf.Bytes())
-	require.Equal(t, int64(3), w.Offset())
-}
-
-func TestNewBinaryReader(t *testing.T) {
-	t.Parallel()
-
-	r := NewBinaryReader(bytes.NewReader([]byte{0x04, 'h', 'i'}))
-	got, err := r.ReadString()
-	require.NoError(t, err)
-	require.Equal(t, "hi", got)
-	require.Equal(t, int64(3), r.Offset())
-}
-
 type writerFunc func([]byte) (int, error)
 
 func (f writerFunc) Write(p []byte) (int, error) {

--- a/avro_test.go
+++ b/avro_test.go
@@ -16,6 +16,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewBinaryWriter(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	w := NewBinaryWriter(&buf)
+	require.NoError(t, w.WriteString("hi"))
+	require.Equal(t, []byte{0x04, 'h', 'i'}, buf.Bytes())
+	require.Equal(t, int64(3), w.Offset())
+}
+
+func TestNewBinaryReader(t *testing.T) {
+	t.Parallel()
+
+	r := NewBinaryReader(bytes.NewReader([]byte{0x04, 'h', 'i'}))
+	got, err := r.ReadString()
+	require.NoError(t, err)
+	require.Equal(t, "hi", got)
+	require.Equal(t, int64(3), r.Offset())
+}
+
 type writerFunc func([]byte) (int, error)
 
 func (f writerFunc) Write(p []byte) (int, error) {

--- a/generic/codec.go
+++ b/generic/codec.go
@@ -22,7 +22,11 @@ type planNode struct {
 // compileSchema validates s and produces matching encode/decode functions.
 // Validation and plan construction happen in a single walk so that NewEncoder
 // and NewDecoder report identical schema-level errors.
-func compileSchema(s avro.Schema, ctx *compileCtx) (*planNode, error) {
+//
+// namespace is the enclosing Avro namespace inherited from a parent named type.
+// Unqualified Refs and inline named types use it when their own Namespace is
+// empty, matching Avro's name resolution rules.
+func compileSchema(s avro.Schema, ctx *compileCtx, namespace string) (*planNode, error) {
 	switch t := s.(type) {
 	case avro.Null:
 		return nullPlan, nil
@@ -41,21 +45,21 @@ func compileSchema(s avro.Schema, ctx *compileCtx) (*planNode, error) {
 	case avro.String:
 		return stringPlan, nil
 	case avro.Ref:
-		return compileRef(t, ctx)
+		return compileRef(t, ctx, namespace)
 	case avro.Record:
-		return compileRecord(t, ctx)
+		return compileRecord(t, ctx, namespace)
 	case avro.Enum:
-		return compileEnum(t, ctx)
+		return compileEnum(t, ctx, namespace)
 	case avro.Array:
-		return compileArray(t, ctx)
+		return compileArray(t, ctx, namespace)
 	case avro.Map:
-		return compileMap(t, ctx)
+		return compileMap(t, ctx, namespace)
 	case avro.Union:
-		return compileUnion(t, ctx)
+		return compileUnion(t, ctx, namespace)
 	case avro.Fixed:
-		return compileFixed(t, ctx)
+		return compileFixed(t, ctx, namespace)
 	case avro.Decimal:
-		return compileDecimal(t, ctx)
+		return compileDecimal(t, ctx, namespace)
 	case avro.UUID:
 		return uuidPlan, nil
 	case avro.Date:
@@ -211,8 +215,12 @@ var (
 
 // ---- composite plans ----
 
-func compileRef(r avro.Ref, ctx *compileCtx) (*planNode, error) {
-	entry, err := ctx.resolveNamed(r.Name, r.Namespace)
+func compileRef(r avro.Ref, ctx *compileCtx, namespace string) (*planNode, error) {
+	ns := r.Namespace
+	if ns == "" {
+		ns = namespace
+	}
+	entry, err := ctx.resolveNamed(r.Name, ns)
 	if err != nil {
 		return nil, err
 	}
@@ -222,14 +230,18 @@ func compileRef(r avro.Ref, ctx *compileCtx) (*planNode, error) {
 	}, nil
 }
 
-func compileRecord(r avro.Record, ctx *compileCtx) (*planNode, error) {
+func compileRecord(r avro.Record, ctx *compileCtx, namespace string) (*planNode, error) {
 	if r.Name == "" {
 		return nil, MissingNameError{Kind: "record"}
+	}
+	ns := r.Namespace
+	if ns == "" {
+		ns = namespace
 	}
 
 	encPtr := new(encodeFn)
 	decPtr := new(decodeFn)
-	if err := ctx.registerNamed(r.Name, r.Namespace, &namedEntry{
+	if err := ctx.registerNamed(r.Name, ns, &namedEntry{
 		kind: namedRecord, schema: r, enc: encPtr, dec: decPtr,
 	}); err != nil {
 		return nil, err
@@ -253,7 +265,7 @@ func compileRecord(r avro.Record, ctx *compileCtx) (*planNode, error) {
 			return nil, InvalidFieldError{Record: r.Name, Index: i, Field: f.Name, Reason: "nil type"}
 		}
 		fieldNames[i] = f.Name
-		node, err := compileSchema(f.Type, ctx)
+		node, err := compileSchema(f.Type, ctx, ns)
 		if err != nil {
 			return nil, FieldCompileError{Record: r.Name, Field: f.Name, Err: err}
 		}
@@ -293,7 +305,7 @@ func compileRecord(r avro.Record, ctx *compileCtx) (*planNode, error) {
 	return &planNode{enc: *encPtr, dec: *decPtr}, nil
 }
 
-func compileEnum(e avro.Enum, ctx *compileCtx) (*planNode, error) {
+func compileEnum(e avro.Enum, ctx *compileCtx, namespace string) (*planNode, error) {
 	if e.Name == "" {
 		return nil, MissingNameError{Kind: "enum"}
 	}
@@ -312,11 +324,15 @@ func compileEnum(e avro.Enum, ctx *compileCtx) (*planNode, error) {
 			return nil, InvalidEnumDefaultError{Enum: e.Name, Default: e.Default}
 		}
 	}
+	ns := e.Namespace
+	if ns == "" {
+		ns = namespace
+	}
 
 	encPtr := new(encodeFn)
 	decPtr := new(decodeFn)
 	symbols := append([]string(nil), e.Symbols...)
-	if err := ctx.registerNamed(e.Name, e.Namespace, &namedEntry{
+	if err := ctx.registerNamed(e.Name, ns, &namedEntry{
 		kind: namedEnum, schema: e, enc: encPtr, dec: decPtr,
 		symbolIndex: idx, symbols: symbols,
 	}); err != nil {
@@ -348,11 +364,11 @@ func compileEnum(e avro.Enum, ctx *compileCtx) (*planNode, error) {
 	return &planNode{enc: *encPtr, dec: *decPtr}, nil
 }
 
-func compileArray(a avro.Array, ctx *compileCtx) (*planNode, error) {
+func compileArray(a avro.Array, ctx *compileCtx, namespace string) (*planNode, error) {
 	if a.Items == nil {
 		return nil, ErrNilArrayItems
 	}
-	item, err := compileSchema(a.Items, ctx)
+	item, err := compileSchema(a.Items, ctx, namespace)
 	if err != nil {
 		return nil, ItemsCompileError{Err: err}
 	}
@@ -403,11 +419,11 @@ func compileArray(a avro.Array, ctx *compileCtx) (*planNode, error) {
 	}, nil
 }
 
-func compileMap(m avro.Map, ctx *compileCtx) (*planNode, error) {
+func compileMap(m avro.Map, ctx *compileCtx, namespace string) (*planNode, error) {
 	if m.Values == nil {
 		return nil, ErrNilMapValues
 	}
-	val, err := compileSchema(m.Values, ctx)
+	val, err := compileSchema(m.Values, ctx, namespace)
 	if err != nil {
 		return nil, ValuesCompileError{Err: err}
 	}
@@ -464,7 +480,7 @@ func compileMap(m avro.Map, ctx *compileCtx) (*planNode, error) {
 	}, nil
 }
 
-func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
+func compileUnion(u avro.Union, ctx *compileCtx, namespace string) (*planNode, error) {
 	if len(u.Types) == 0 {
 		return nil, ErrEmptyUnion
 	}
@@ -478,7 +494,7 @@ func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
 		if _, nested := t.(avro.Union); nested {
 			return nil, NestedUnionError{Index: i}
 		}
-		key, named := unionBranchKey(t)
+		key, named := unionBranchKey(t, namespace)
 		if named {
 			if _, dup := seenNamed[key]; dup {
 				return nil, DuplicateBranchError{Key: key, Named: true}
@@ -490,7 +506,7 @@ func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
 			}
 			seenUnnamed[key] = struct{}{}
 		}
-		node, err := compileSchema(t, ctx)
+		node, err := compileSchema(t, ctx, namespace)
 		if err != nil {
 			return nil, BranchCompileError{Index: i, Err: err}
 		}
@@ -527,7 +543,13 @@ func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
 	}, nil
 }
 
-func unionBranchKey(s avro.Schema) (string, bool) {
+func unionBranchKey(s avro.Schema, namespace string) (string, bool) {
+	resolveNS := func(declared string) string {
+		if declared != "" {
+			return declared
+		}
+		return namespace
+	}
 	switch t := s.(type) {
 	case avro.Null:
 		return "null", false
@@ -550,28 +572,32 @@ func unionBranchKey(s avro.Schema) (string, bool) {
 	case avro.Map:
 		return "map", false
 	case avro.Record:
-		return fullName(t.Name, t.Namespace), true
+		return fullName(t.Name, resolveNS(t.Namespace)), true
 	case avro.Enum:
-		return fullName(t.Name, t.Namespace), true
+		return fullName(t.Name, resolveNS(t.Namespace)), true
 	case avro.Fixed:
-		return fullName(t.Name, t.Namespace), true
+		return fullName(t.Name, resolveNS(t.Namespace)), true
 	case avro.Ref:
-		return fullName(t.Name, t.Namespace), true
+		return fullName(t.Name, resolveNS(t.Namespace)), true
 	default:
 		return fmt.Sprintf("%T", s), false
 	}
 }
 
-func compileFixed(f avro.Fixed, ctx *compileCtx) (*planNode, error) {
+func compileFixed(f avro.Fixed, ctx *compileCtx, namespace string) (*planNode, error) {
 	if f.Name == "" {
 		return nil, MissingNameError{Kind: "fixed"}
 	}
 	if f.Size <= 0 {
 		return nil, InvalidFixedSizeError{Name: f.Name, Size: f.Size}
 	}
+	ns := f.Namespace
+	if ns == "" {
+		ns = namespace
+	}
 	encPtr := new(encodeFn)
 	decPtr := new(decodeFn)
-	if err := ctx.registerNamed(f.Name, f.Namespace, &namedEntry{
+	if err := ctx.registerNamed(f.Name, ns, &namedEntry{
 		kind: namedFixed, schema: f, enc: encPtr, dec: decPtr, size: f.Size,
 	}); err != nil {
 		return nil, err
@@ -600,7 +626,7 @@ func compileFixed(f avro.Fixed, ctx *compileCtx) (*planNode, error) {
 
 // ---- logical type plans ----
 
-func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
+func compileDecimal(d avro.Decimal, ctx *compileCtx, namespace string) (*planNode, error) {
 	if d.Precision <= 0 {
 		return nil, InvalidPrecisionError{Precision: d.Precision}
 	}
@@ -610,6 +636,7 @@ func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
 	switch under := d.Underlying.(type) {
 	case avro.Bytes:
 		precision := d.Precision
+		limit := precisionLimit(precision)
 		return &planNode{
 			enc: func(w *avro.BinaryWriter, v Value) error {
 				dec, ok := v.(Decimal)
@@ -619,7 +646,7 @@ func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
 				if dec.Unscaled == nil {
 					return ErrNilDecimalUnscaled
 				}
-				if !decimalFits(dec.Unscaled, precision) {
+				if !decimalFits(dec.Unscaled, limit) {
 					return PrecisionOverflowError{Precision: precision}
 				}
 				return w.WriteBytes(twosComplementBytes(dec.Unscaled))
@@ -633,37 +660,55 @@ func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
 			},
 		}, nil
 	case avro.Fixed:
+		if under.Name == "" {
+			return nil, MissingNameError{Kind: "fixed"}
+		}
 		if under.Size <= 0 {
 			return nil, InvalidFixedSizeError{Name: under.Name, Size: under.Size}
 		}
 		size := under.Size
 		precision := d.Precision
-		return &planNode{
-			enc: func(w *avro.BinaryWriter, v Value) error {
-				dec, ok := v.(Decimal)
-				if !ok {
-					return TypeMismatchError{Expected: "decimal", Got: v}
-				}
-				if dec.Unscaled == nil {
-					return ErrNilDecimalUnscaled
-				}
-				if !decimalFits(dec.Unscaled, precision) {
-					return PrecisionOverflowError{Precision: precision}
-				}
-				b := twosComplementBytes(dec.Unscaled)
-				if len(b) > size {
-					return DecimalSizeError{Encoded: len(b), FixedSize: size}
-				}
-				return w.WriteFixed(padTwosComplement(b, size, dec.Unscaled.Sign()))
-			},
-			dec: func(r *avro.BinaryReader) (Value, error) {
-				b, err := r.ReadFixed(size)
-				if err != nil {
-					return nil, err
-				}
-				return Decimal{Unscaled: bytesToBigInt(b)}, nil
-			},
-		}, nil
+		limit := precisionLimit(precision)
+		ns := under.Namespace
+		if ns == "" {
+			ns = namespace
+		}
+
+		// The underlying fixed is a named type per the Avro spec. Register it
+		// so a Ref to its name resolves to the same decimal-over-fixed plan
+		// rather than a raw fixed-bytes plan.
+		encPtr := new(encodeFn)
+		decPtr := new(decodeFn)
+		if err := ctx.registerNamed(under.Name, ns, &namedEntry{
+			kind: namedFixed, schema: d, enc: encPtr, dec: decPtr, size: size,
+		}); err != nil {
+			return nil, err
+		}
+		*encPtr = func(w *avro.BinaryWriter, v Value) error {
+			dec, ok := v.(Decimal)
+			if !ok {
+				return TypeMismatchError{Expected: "decimal", Got: v}
+			}
+			if dec.Unscaled == nil {
+				return ErrNilDecimalUnscaled
+			}
+			if !decimalFits(dec.Unscaled, limit) {
+				return PrecisionOverflowError{Precision: precision}
+			}
+			b := twosComplementBytes(dec.Unscaled)
+			if len(b) > size {
+				return DecimalSizeError{Encoded: len(b), FixedSize: size}
+			}
+			return w.WriteFixed(padTwosComplement(b, size, dec.Unscaled.Sign()))
+		}
+		*decPtr = func(r *avro.BinaryReader) (Value, error) {
+			b, err := r.ReadFixed(size)
+			if err != nil {
+				return nil, err
+			}
+			return Decimal{Unscaled: bytesToBigInt(b)}, nil
+		}
+		return &planNode{enc: *encPtr, dec: *decPtr}, nil
 	default:
 		return nil, InvalidDecimalUnderlyingError{Underlying: d.Underlying}
 	}
@@ -854,8 +899,13 @@ func padTwosComplement(b []byte, size, sign int) []byte {
 	return out
 }
 
-func decimalFits(x *big.Int, precision int) bool {
-	limit := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
-	abs := new(big.Int).Abs(x)
-	return abs.Cmp(limit) < 0
+// precisionLimit returns 10^precision as a *big.Int. It is computed once per
+// compiled decimal plan so encoding does not re-allocate on every call.
+func precisionLimit(precision int) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+}
+
+// decimalFits reports whether x's magnitude is strictly less than limit.
+func decimalFits(x, limit *big.Int) bool {
+	return new(big.Int).Abs(x).Cmp(limit) < 0
 }

--- a/generic/codec.go
+++ b/generic/codec.go
@@ -79,7 +79,7 @@ func compileSchema(s avro.Schema, ctx *compileCtx) (*planNode, error) {
 	case avro.Duration:
 		return durationPlan, nil
 	default:
-		return nil, fmt.Errorf("avro/generic: unsupported schema type %T", s)
+		return nil, UnsupportedSchemaError{Schema: s}
 	}
 }
 
@@ -89,7 +89,7 @@ var (
 	nullPlan = &planNode{
 		enc: func(_ *avro.BinaryWriter, v Value) error {
 			if _, ok := v.(Null); !ok {
-				return typeMismatch("null", v)
+				return TypeMismatchError{Expected: "null", Got: v}
 			}
 			return nil
 		},
@@ -224,7 +224,7 @@ func compileRef(r avro.Ref, ctx *compileCtx) (*planNode, error) {
 
 func compileRecord(r avro.Record, ctx *compileCtx) (*planNode, error) {
 	if r.Name == "" {
-		return nil, fmt.Errorf("avro/generic: record missing name")
+		return nil, MissingNameError{Kind: "record"}
 	}
 
 	encPtr := new(encodeFn)
@@ -240,22 +240,22 @@ func compileRecord(r avro.Record, ctx *compileCtx) (*planNode, error) {
 	fieldNodes := make([]*planNode, len(r.Fields))
 	for i, f := range r.Fields {
 		if f == nil {
-			return nil, fmt.Errorf("avro/generic: record %q: nil field at index %d", r.Name, i)
+			return nil, InvalidFieldError{Record: r.Name, Index: i, Reason: "nil field"}
 		}
 		if f.Name == "" {
-			return nil, fmt.Errorf("avro/generic: record %q: field %d missing name", r.Name, i)
+			return nil, InvalidFieldError{Record: r.Name, Index: i, Reason: "missing name"}
 		}
 		if _, dup := seen[f.Name]; dup {
-			return nil, fmt.Errorf("avro/generic: record %q: duplicate field name %q", r.Name, f.Name)
+			return nil, DuplicateFieldError{Record: r.Name, Field: f.Name}
 		}
 		seen[f.Name] = struct{}{}
 		if f.Type == nil {
-			return nil, fmt.Errorf("avro/generic: record %q: field %q has nil type", r.Name, f.Name)
+			return nil, InvalidFieldError{Record: r.Name, Index: i, Field: f.Name, Reason: "nil type"}
 		}
 		fieldNames[i] = f.Name
 		node, err := compileSchema(f.Type, ctx)
 		if err != nil {
-			return nil, fmt.Errorf("record %q field %q: %w", r.Name, f.Name, err)
+			return nil, FieldCompileError{Record: r.Name, Field: f.Name, Err: err}
 		}
 		fieldNodes[i] = node
 	}
@@ -264,14 +264,14 @@ func compileRecord(r avro.Record, ctx *compileCtx) (*planNode, error) {
 	*encPtr = func(w *avro.BinaryWriter, v Value) error {
 		rec, ok := v.(Record)
 		if !ok {
-			return typeMismatch(fmt.Sprintf("record %q", name), v)
+			return TypeMismatchError{Expected: fmt.Sprintf("record %q", name), Got: v}
 		}
 		if len(rec.Fields) != len(fieldNames) {
-			return fmt.Errorf("avro/generic: record %q: expected %d fields, got %d", name, len(fieldNames), len(rec.Fields))
+			return FieldCountError{Record: name, Expected: len(fieldNames), Got: len(rec.Fields)}
 		}
 		for i, f := range rec.Fields {
 			if f.Name != fieldNames[i] {
-				return fmt.Errorf("avro/generic: record %q: field %d: expected name %q, got %q", name, i, fieldNames[i], f.Name)
+				return FieldNameError{Record: name, Index: i, Expected: fieldNames[i], Got: f.Name}
 			}
 			if err := fieldNodes[i].enc(w, f.Value); err != nil {
 				return err
@@ -295,21 +295,21 @@ func compileRecord(r avro.Record, ctx *compileCtx) (*planNode, error) {
 
 func compileEnum(e avro.Enum, ctx *compileCtx) (*planNode, error) {
 	if e.Name == "" {
-		return nil, fmt.Errorf("avro/generic: enum missing name")
+		return nil, MissingNameError{Kind: "enum"}
 	}
 	if len(e.Symbols) == 0 {
-		return nil, fmt.Errorf("avro/generic: enum %q has no symbols", e.Name)
+		return nil, EmptySymbolsError{Enum: e.Name}
 	}
 	idx := make(map[string]int, len(e.Symbols))
 	for i, s := range e.Symbols {
 		if _, dup := idx[s]; dup {
-			return nil, fmt.Errorf("avro/generic: enum %q: duplicate symbol %q", e.Name, s)
+			return nil, DuplicateSymbolError{Enum: e.Name, Symbol: s}
 		}
 		idx[s] = i
 	}
 	if e.Default != "" {
 		if _, ok := idx[e.Default]; !ok {
-			return nil, fmt.Errorf("avro/generic: enum %q: default %q not in symbols", e.Name, e.Default)
+			return nil, InvalidEnumDefaultError{Enum: e.Name, Default: e.Default}
 		}
 	}
 
@@ -327,11 +327,11 @@ func compileEnum(e avro.Enum, ctx *compileCtx) (*planNode, error) {
 	*encPtr = func(w *avro.BinaryWriter, v Value) error {
 		en, ok := v.(Enum)
 		if !ok {
-			return typeMismatch(fmt.Sprintf("enum %q", name), v)
+			return TypeMismatchError{Expected: fmt.Sprintf("enum %q", name), Got: v}
 		}
 		i, ok := idx[en.Symbol]
 		if !ok {
-			return fmt.Errorf("avro/generic: enum %q: symbol %q not in schema", name, en.Symbol)
+			return UnknownSymbolError{Enum: name, Symbol: en.Symbol}
 		}
 		return w.WriteInt(int32(i))
 	}
@@ -341,7 +341,7 @@ func compileEnum(e avro.Enum, ctx *compileCtx) (*planNode, error) {
 			return nil, err
 		}
 		if int(i) < 0 || int(i) >= len(symbols) {
-			return nil, fmt.Errorf("avro/generic: enum %q: index %d out of range [0, %d)", name, i, len(symbols))
+			return nil, IndexOutOfRangeError{Kind: "enum", Name: name, Index: int64(i), Len: len(symbols)}
 		}
 		return Enum{Symbol: symbols[i]}, nil
 	}
@@ -350,17 +350,17 @@ func compileEnum(e avro.Enum, ctx *compileCtx) (*planNode, error) {
 
 func compileArray(a avro.Array, ctx *compileCtx) (*planNode, error) {
 	if a.Items == nil {
-		return nil, fmt.Errorf("avro/generic: array has nil items schema")
+		return nil, ErrNilArrayItems
 	}
 	item, err := compileSchema(a.Items, ctx)
 	if err != nil {
-		return nil, fmt.Errorf("array items: %w", err)
+		return nil, ItemsCompileError{Err: err}
 	}
 	return &planNode{
 		enc: func(w *avro.BinaryWriter, v Value) error {
 			arr, ok := v.(Array)
 			if !ok {
-				return typeMismatch("array", v)
+				return TypeMismatchError{Expected: "array", Got: v}
 			}
 			if len(arr) > 0 {
 				if err := w.WriteLong(int64(len(arr))); err != nil {
@@ -405,17 +405,17 @@ func compileArray(a avro.Array, ctx *compileCtx) (*planNode, error) {
 
 func compileMap(m avro.Map, ctx *compileCtx) (*planNode, error) {
 	if m.Values == nil {
-		return nil, fmt.Errorf("avro/generic: map has nil values schema")
+		return nil, ErrNilMapValues
 	}
 	val, err := compileSchema(m.Values, ctx)
 	if err != nil {
-		return nil, fmt.Errorf("map values: %w", err)
+		return nil, ValuesCompileError{Err: err}
 	}
 	return &planNode{
 		enc: func(w *avro.BinaryWriter, v Value) error {
 			mp, ok := v.(Map)
 			if !ok {
-				return typeMismatch("map", v)
+				return TypeMismatchError{Expected: "map", Got: v}
 			}
 			if len(mp) > 0 {
 				if err := w.WriteLong(int64(len(mp))); err != nil {
@@ -466,33 +466,33 @@ func compileMap(m avro.Map, ctx *compileCtx) (*planNode, error) {
 
 func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
 	if len(u.Types) == 0 {
-		return nil, fmt.Errorf("avro/generic: union has no branches")
+		return nil, ErrEmptyUnion
 	}
 	branches := make([]*planNode, len(u.Types))
 	seenUnnamed := make(map[string]struct{})
 	seenNamed := make(map[string]struct{})
 	for i, t := range u.Types {
 		if t == nil {
-			return nil, fmt.Errorf("avro/generic: union branch %d is nil", i)
+			return nil, NilBranchError{Index: i}
 		}
 		if _, nested := t.(avro.Union); nested {
-			return nil, fmt.Errorf("avro/generic: union branch %d is itself a union", i)
+			return nil, NestedUnionError{Index: i}
 		}
 		key, named := unionBranchKey(t)
 		if named {
 			if _, dup := seenNamed[key]; dup {
-				return nil, fmt.Errorf("avro/generic: union: duplicate named branch %q", key)
+				return nil, DuplicateBranchError{Key: key, Named: true}
 			}
 			seenNamed[key] = struct{}{}
 		} else {
 			if _, dup := seenUnnamed[key]; dup {
-				return nil, fmt.Errorf("avro/generic: union: duplicate %s branch", key)
+				return nil, DuplicateBranchError{Key: key, Named: false}
 			}
 			seenUnnamed[key] = struct{}{}
 		}
 		node, err := compileSchema(t, ctx)
 		if err != nil {
-			return nil, fmt.Errorf("union branch %d: %w", i, err)
+			return nil, BranchCompileError{Index: i, Err: err}
 		}
 		branches[i] = node
 	}
@@ -500,10 +500,10 @@ func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
 		enc: func(w *avro.BinaryWriter, v Value) error {
 			un, ok := v.(Union)
 			if !ok {
-				return typeMismatch("union", v)
+				return TypeMismatchError{Expected: "union", Got: v}
 			}
 			if un.Index < 0 || un.Index >= len(branches) {
-				return fmt.Errorf("avro/generic: union: index %d out of range [0, %d)", un.Index, len(branches))
+				return IndexOutOfRangeError{Kind: "union", Index: int64(un.Index), Len: len(branches)}
 			}
 			if err := w.WriteLong(int64(un.Index)); err != nil {
 				return err
@@ -516,7 +516,7 @@ func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
 				return nil, err
 			}
 			if i < 0 || int(i) >= len(branches) {
-				return nil, fmt.Errorf("avro/generic: union: index %d out of range [0, %d)", i, len(branches))
+				return nil, IndexOutOfRangeError{Kind: "union", Index: i, Len: len(branches)}
 			}
 			val, err := branches[i].dec(r)
 			if err != nil {
@@ -564,10 +564,10 @@ func unionBranchKey(s avro.Schema) (string, bool) {
 
 func compileFixed(f avro.Fixed, ctx *compileCtx) (*planNode, error) {
 	if f.Name == "" {
-		return nil, fmt.Errorf("avro/generic: fixed missing name")
+		return nil, MissingNameError{Kind: "fixed"}
 	}
 	if f.Size <= 0 {
-		return nil, fmt.Errorf("avro/generic: fixed %q: size must be > 0, got %d", f.Name, f.Size)
+		return nil, InvalidFixedSizeError{Name: f.Name, Size: f.Size}
 	}
 	encPtr := new(encodeFn)
 	decPtr := new(decodeFn)
@@ -581,10 +581,10 @@ func compileFixed(f avro.Fixed, ctx *compileCtx) (*planNode, error) {
 	*encPtr = func(w *avro.BinaryWriter, v Value) error {
 		fx, ok := v.(Fixed)
 		if !ok {
-			return typeMismatch(fmt.Sprintf("fixed %q", name), v)
+			return TypeMismatchError{Expected: fmt.Sprintf("fixed %q", name), Got: v}
 		}
 		if len(fx) != size {
-			return fmt.Errorf("avro/generic: fixed %q: expected %d bytes, got %d", name, size, len(fx))
+			return FixedSizeError{Name: name, Expected: size, Got: len(fx)}
 		}
 		return w.WriteFixed([]byte(fx))
 	}
@@ -602,10 +602,10 @@ func compileFixed(f avro.Fixed, ctx *compileCtx) (*planNode, error) {
 
 func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
 	if d.Precision <= 0 {
-		return nil, fmt.Errorf("avro/generic: decimal: precision must be > 0, got %d", d.Precision)
+		return nil, InvalidPrecisionError{Precision: d.Precision}
 	}
 	if d.Scale < 0 || d.Scale > d.Precision {
-		return nil, fmt.Errorf("avro/generic: decimal: scale %d out of range [0, %d]", d.Scale, d.Precision)
+		return nil, InvalidScaleError{Precision: d.Precision, Scale: d.Scale}
 	}
 	switch under := d.Underlying.(type) {
 	case avro.Bytes:
@@ -614,13 +614,13 @@ func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
 			enc: func(w *avro.BinaryWriter, v Value) error {
 				dec, ok := v.(Decimal)
 				if !ok {
-					return typeMismatch("decimal", v)
+					return TypeMismatchError{Expected: "decimal", Got: v}
 				}
 				if dec.Unscaled == nil {
-					return fmt.Errorf("avro/generic: decimal: nil Unscaled")
+					return ErrNilDecimalUnscaled
 				}
 				if !decimalFits(dec.Unscaled, precision) {
-					return fmt.Errorf("avro/generic: decimal: value exceeds precision %d", precision)
+					return PrecisionOverflowError{Precision: precision}
 				}
 				return w.WriteBytes(twosComplementBytes(dec.Unscaled))
 			},
@@ -634,7 +634,7 @@ func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
 		}, nil
 	case avro.Fixed:
 		if under.Size <= 0 {
-			return nil, fmt.Errorf("avro/generic: decimal: underlying fixed has invalid size %d", under.Size)
+			return nil, InvalidFixedSizeError{Name: under.Name, Size: under.Size}
 		}
 		size := under.Size
 		precision := d.Precision
@@ -642,17 +642,17 @@ func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
 			enc: func(w *avro.BinaryWriter, v Value) error {
 				dec, ok := v.(Decimal)
 				if !ok {
-					return typeMismatch("decimal", v)
+					return TypeMismatchError{Expected: "decimal", Got: v}
 				}
 				if dec.Unscaled == nil {
-					return fmt.Errorf("avro/generic: decimal: nil Unscaled")
+					return ErrNilDecimalUnscaled
 				}
 				if !decimalFits(dec.Unscaled, precision) {
-					return fmt.Errorf("avro/generic: decimal: value exceeds precision %d", precision)
+					return PrecisionOverflowError{Precision: precision}
 				}
 				b := twosComplementBytes(dec.Unscaled)
 				if len(b) > size {
-					return fmt.Errorf("avro/generic: decimal: encoded %d bytes exceeds fixed size %d", len(b), size)
+					return DecimalSizeError{Encoded: len(b), FixedSize: size}
 				}
 				return w.WriteFixed(padTwosComplement(b, size, dec.Unscaled.Sign()))
 			},
@@ -665,7 +665,7 @@ func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
 			},
 		}, nil
 	default:
-		return nil, fmt.Errorf("avro/generic: decimal: underlying must be bytes or fixed, got %T", d.Underlying)
+		return nil, InvalidDecimalUnderlyingError{Underlying: d.Underlying}
 	}
 }
 
@@ -794,7 +794,7 @@ func newLongLogical(name string, wrap func(int64) Value, unwrap func(Value) (int
 // ---- helpers ----
 
 func typeMismatch(want string, got Value) error {
-	return fmt.Errorf("avro/generic: type mismatch: schema expects %s, got %T", want, got)
+	return TypeMismatchError{Expected: want, Got: got}
 }
 
 // twosComplementBytes returns the minimum-length two's-complement big-endian

--- a/generic/codec.go
+++ b/generic/codec.go
@@ -494,6 +494,16 @@ func compileUnion(u avro.Union, ctx *compileCtx, namespace string) (*planNode, e
 		if _, nested := t.(avro.Union); nested {
 			return nil, NestedUnionError{Index: i}
 		}
+		// Compile (and thus validate) each branch before checking for duplicate
+		// keys. Otherwise a schema-level error in a branch (e.g. a decimal with
+		// an invalid underlying) is masked by a spurious DuplicateBranchError
+		// when the invalid branch's key collapses to the same wire type as an
+		// earlier branch.
+		node, err := compileSchema(t, ctx, namespace)
+		if err != nil {
+			return nil, BranchCompileError{Index: i, Err: err}
+		}
+		branches[i] = node
 		key, named := unionBranchKey(t, namespace)
 		if named {
 			if _, dup := seenNamed[key]; dup {
@@ -506,11 +516,6 @@ func compileUnion(u avro.Union, ctx *compileCtx, namespace string) (*planNode, e
 			}
 			seenUnnamed[key] = struct{}{}
 		}
-		node, err := compileSchema(t, ctx, namespace)
-		if err != nil {
-			return nil, BranchCompileError{Index: i, Err: err}
-		}
-		branches[i] = node
 	}
 	return &planNode{
 		enc: func(w *avro.BinaryWriter, v Value) error {
@@ -803,7 +808,7 @@ var (
 func compileDuration(d avro.Duration, ctx *compileCtx, namespace string) (*planNode, error) {
 	under := d.Underlying
 	if under.Size != 0 && under.Size != 12 {
-		return nil, InvalidFixedSizeError{Name: under.Name, Size: under.Size}
+		return nil, InvalidDurationSizeError{Size: under.Size}
 	}
 	name := under.Name
 	if name == "" {

--- a/generic/codec.go
+++ b/generic/codec.go
@@ -1,0 +1,861 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/z5labs/avro-go"
+)
+
+// planNode pairs an encode and decode function compiled from one schema node.
+type planNode struct {
+	enc encodeFn
+	dec decodeFn
+}
+
+// compileSchema validates s and produces matching encode/decode functions.
+// Validation and plan construction happen in a single walk so that NewEncoder
+// and NewDecoder report identical schema-level errors.
+func compileSchema(s avro.Schema, ctx *compileCtx) (*planNode, error) {
+	switch t := s.(type) {
+	case avro.Null:
+		return nullPlan, nil
+	case avro.Boolean:
+		return booleanPlan, nil
+	case avro.Int:
+		return intPlan, nil
+	case avro.Long:
+		return longPlan, nil
+	case avro.Float:
+		return floatPlan, nil
+	case avro.Double:
+		return doublePlan, nil
+	case avro.Bytes:
+		return bytesPlan, nil
+	case avro.String:
+		return stringPlan, nil
+	case avro.Ref:
+		return compileRef(t, ctx)
+	case avro.Record:
+		return compileRecord(t, ctx)
+	case avro.Enum:
+		return compileEnum(t, ctx)
+	case avro.Array:
+		return compileArray(t, ctx)
+	case avro.Map:
+		return compileMap(t, ctx)
+	case avro.Union:
+		return compileUnion(t, ctx)
+	case avro.Fixed:
+		return compileFixed(t, ctx)
+	case avro.Decimal:
+		return compileDecimal(t, ctx)
+	case avro.UUID:
+		return uuidPlan, nil
+	case avro.Date:
+		return datePlan, nil
+	case avro.TimeMillis:
+		return timeMillisPlan, nil
+	case avro.TimeMicros:
+		return timeMicrosPlan, nil
+	case avro.TimestampMillis:
+		return timestampMillisPlan, nil
+	case avro.TimestampMicros:
+		return timestampMicrosPlan, nil
+	case avro.TimestampNanos:
+		return timestampNanosPlan, nil
+	case avro.LocalTimestampMillis:
+		return localTimestampMillisPlan, nil
+	case avro.LocalTimestampMicros:
+		return localTimestampMicrosPlan, nil
+	case avro.LocalTimestampNanos:
+		return localTimestampNanosPlan, nil
+	case avro.Duration:
+		return durationPlan, nil
+	default:
+		return nil, fmt.Errorf("avro/generic: unsupported schema type %T", s)
+	}
+}
+
+// ---- primitive plans ----
+
+var (
+	nullPlan = &planNode{
+		enc: func(_ *avro.BinaryWriter, v Value) error {
+			if _, ok := v.(Null); !ok {
+				return typeMismatch("null", v)
+			}
+			return nil
+		},
+		dec: func(_ *avro.BinaryReader) (Value, error) { return Null{}, nil },
+	}
+	booleanPlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			b, ok := v.(Bool)
+			if !ok {
+				return typeMismatch("boolean", v)
+			}
+			return w.WriteBool(bool(b))
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			b, err := r.ReadBool()
+			if err != nil {
+				return nil, err
+			}
+			return Bool(b), nil
+		},
+	}
+	intPlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			i, ok := v.(Int)
+			if !ok {
+				return typeMismatch("int", v)
+			}
+			return w.WriteInt(int32(i))
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			i, err := r.ReadInt()
+			if err != nil {
+				return nil, err
+			}
+			return Int(i), nil
+		},
+	}
+	longPlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			l, ok := v.(Long)
+			if !ok {
+				return typeMismatch("long", v)
+			}
+			return w.WriteLong(int64(l))
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			l, err := r.ReadLong()
+			if err != nil {
+				return nil, err
+			}
+			return Long(l), nil
+		},
+	}
+	floatPlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			f, ok := v.(Float)
+			if !ok {
+				return typeMismatch("float", v)
+			}
+			return w.WriteFloat(float32(f))
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			f, err := r.ReadFloat()
+			if err != nil {
+				return nil, err
+			}
+			return Float(f), nil
+		},
+	}
+	doublePlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			d, ok := v.(Double)
+			if !ok {
+				return typeMismatch("double", v)
+			}
+			return w.WriteDouble(float64(d))
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			d, err := r.ReadDouble()
+			if err != nil {
+				return nil, err
+			}
+			return Double(d), nil
+		},
+	}
+	bytesPlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			b, ok := v.(Bytes)
+			if !ok {
+				return typeMismatch("bytes", v)
+			}
+			return w.WriteBytes([]byte(b))
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			b, err := r.ReadBytes()
+			if err != nil {
+				return nil, err
+			}
+			return Bytes(b), nil
+		},
+	}
+	stringPlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			s, ok := v.(String)
+			if !ok {
+				return typeMismatch("string", v)
+			}
+			return w.WriteString(string(s))
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			s, err := r.ReadString()
+			if err != nil {
+				return nil, err
+			}
+			return String(s), nil
+		},
+	}
+)
+
+// ---- composite plans ----
+
+func compileRef(r avro.Ref, ctx *compileCtx) (*planNode, error) {
+	entry, err := ctx.resolveNamed(r.Name, r.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error { return (*entry.enc)(w, v) },
+		dec: func(rd *avro.BinaryReader) (Value, error) { return (*entry.dec)(rd) },
+	}, nil
+}
+
+func compileRecord(r avro.Record, ctx *compileCtx) (*planNode, error) {
+	if r.Name == "" {
+		return nil, fmt.Errorf("avro/generic: record missing name")
+	}
+
+	encPtr := new(encodeFn)
+	decPtr := new(decodeFn)
+	if err := ctx.registerNamed(r.Name, r.Namespace, &namedEntry{
+		kind: namedRecord, schema: r, enc: encPtr, dec: decPtr,
+	}); err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(r.Fields))
+	fieldNames := make([]string, len(r.Fields))
+	fieldNodes := make([]*planNode, len(r.Fields))
+	for i, f := range r.Fields {
+		if f == nil {
+			return nil, fmt.Errorf("avro/generic: record %q: nil field at index %d", r.Name, i)
+		}
+		if f.Name == "" {
+			return nil, fmt.Errorf("avro/generic: record %q: field %d missing name", r.Name, i)
+		}
+		if _, dup := seen[f.Name]; dup {
+			return nil, fmt.Errorf("avro/generic: record %q: duplicate field name %q", r.Name, f.Name)
+		}
+		seen[f.Name] = struct{}{}
+		if f.Type == nil {
+			return nil, fmt.Errorf("avro/generic: record %q: field %q has nil type", r.Name, f.Name)
+		}
+		fieldNames[i] = f.Name
+		node, err := compileSchema(f.Type, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("record %q field %q: %w", r.Name, f.Name, err)
+		}
+		fieldNodes[i] = node
+	}
+
+	name := r.Name
+	*encPtr = func(w *avro.BinaryWriter, v Value) error {
+		rec, ok := v.(Record)
+		if !ok {
+			return typeMismatch(fmt.Sprintf("record %q", name), v)
+		}
+		if len(rec.Fields) != len(fieldNames) {
+			return fmt.Errorf("avro/generic: record %q: expected %d fields, got %d", name, len(fieldNames), len(rec.Fields))
+		}
+		for i, f := range rec.Fields {
+			if f.Name != fieldNames[i] {
+				return fmt.Errorf("avro/generic: record %q: field %d: expected name %q, got %q", name, i, fieldNames[i], f.Name)
+			}
+			if err := fieldNodes[i].enc(w, f.Value); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	*decPtr = func(rd *avro.BinaryReader) (Value, error) {
+		fields := make([]Field, len(fieldNames))
+		for i, fname := range fieldNames {
+			val, err := fieldNodes[i].dec(rd)
+			if err != nil {
+				return nil, err
+			}
+			fields[i] = Field{Name: fname, Value: val}
+		}
+		return Record{Fields: fields}, nil
+	}
+	return &planNode{enc: *encPtr, dec: *decPtr}, nil
+}
+
+func compileEnum(e avro.Enum, ctx *compileCtx) (*planNode, error) {
+	if e.Name == "" {
+		return nil, fmt.Errorf("avro/generic: enum missing name")
+	}
+	if len(e.Symbols) == 0 {
+		return nil, fmt.Errorf("avro/generic: enum %q has no symbols", e.Name)
+	}
+	idx := make(map[string]int, len(e.Symbols))
+	for i, s := range e.Symbols {
+		if _, dup := idx[s]; dup {
+			return nil, fmt.Errorf("avro/generic: enum %q: duplicate symbol %q", e.Name, s)
+		}
+		idx[s] = i
+	}
+	if e.Default != "" {
+		if _, ok := idx[e.Default]; !ok {
+			return nil, fmt.Errorf("avro/generic: enum %q: default %q not in symbols", e.Name, e.Default)
+		}
+	}
+
+	encPtr := new(encodeFn)
+	decPtr := new(decodeFn)
+	symbols := append([]string(nil), e.Symbols...)
+	if err := ctx.registerNamed(e.Name, e.Namespace, &namedEntry{
+		kind: namedEnum, schema: e, enc: encPtr, dec: decPtr,
+		symbolIndex: idx, symbols: symbols,
+	}); err != nil {
+		return nil, err
+	}
+
+	name := e.Name
+	*encPtr = func(w *avro.BinaryWriter, v Value) error {
+		en, ok := v.(Enum)
+		if !ok {
+			return typeMismatch(fmt.Sprintf("enum %q", name), v)
+		}
+		i, ok := idx[en.Symbol]
+		if !ok {
+			return fmt.Errorf("avro/generic: enum %q: symbol %q not in schema", name, en.Symbol)
+		}
+		return w.WriteInt(int32(i))
+	}
+	*decPtr = func(r *avro.BinaryReader) (Value, error) {
+		i, err := r.ReadInt()
+		if err != nil {
+			return nil, err
+		}
+		if int(i) < 0 || int(i) >= len(symbols) {
+			return nil, fmt.Errorf("avro/generic: enum %q: index %d out of range [0, %d)", name, i, len(symbols))
+		}
+		return Enum{Symbol: symbols[i]}, nil
+	}
+	return &planNode{enc: *encPtr, dec: *decPtr}, nil
+}
+
+func compileArray(a avro.Array, ctx *compileCtx) (*planNode, error) {
+	if a.Items == nil {
+		return nil, fmt.Errorf("avro/generic: array has nil items schema")
+	}
+	item, err := compileSchema(a.Items, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("array items: %w", err)
+	}
+	return &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			arr, ok := v.(Array)
+			if !ok {
+				return typeMismatch("array", v)
+			}
+			if len(arr) > 0 {
+				if err := w.WriteLong(int64(len(arr))); err != nil {
+					return err
+				}
+				for _, it := range arr {
+					if err := item.enc(w, it); err != nil {
+						return err
+					}
+				}
+			}
+			return w.WriteLong(0)
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			out := Array{}
+			for {
+				count, err := r.ReadLong()
+				if err != nil {
+					return nil, err
+				}
+				if count == 0 {
+					return out, nil
+				}
+				if count < 0 {
+					// Negative count means the next long is a byte size we can skip past.
+					count = -count
+					if _, err := r.ReadLong(); err != nil {
+						return nil, err
+					}
+				}
+				for i := int64(0); i < count; i++ {
+					val, err := item.dec(r)
+					if err != nil {
+						return nil, err
+					}
+					out = append(out, val)
+				}
+			}
+		},
+	}, nil
+}
+
+func compileMap(m avro.Map, ctx *compileCtx) (*planNode, error) {
+	if m.Values == nil {
+		return nil, fmt.Errorf("avro/generic: map has nil values schema")
+	}
+	val, err := compileSchema(m.Values, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("map values: %w", err)
+	}
+	return &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			mp, ok := v.(Map)
+			if !ok {
+				return typeMismatch("map", v)
+			}
+			if len(mp) > 0 {
+				if err := w.WriteLong(int64(len(mp))); err != nil {
+					return err
+				}
+				for k, vv := range mp {
+					if err := w.WriteString(k); err != nil {
+						return err
+					}
+					if err := val.enc(w, vv); err != nil {
+						return err
+					}
+				}
+			}
+			return w.WriteLong(0)
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			out := Map{}
+			for {
+				count, err := r.ReadLong()
+				if err != nil {
+					return nil, err
+				}
+				if count == 0 {
+					return out, nil
+				}
+				if count < 0 {
+					count = -count
+					if _, err := r.ReadLong(); err != nil {
+						return nil, err
+					}
+				}
+				for i := int64(0); i < count; i++ {
+					k, err := r.ReadString()
+					if err != nil {
+						return nil, err
+					}
+					vv, err := val.dec(r)
+					if err != nil {
+						return nil, err
+					}
+					out[k] = vv
+				}
+			}
+		},
+	}, nil
+}
+
+func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
+	if len(u.Types) == 0 {
+		return nil, fmt.Errorf("avro/generic: union has no branches")
+	}
+	branches := make([]*planNode, len(u.Types))
+	seenUnnamed := make(map[string]struct{})
+	seenNamed := make(map[string]struct{})
+	for i, t := range u.Types {
+		if t == nil {
+			return nil, fmt.Errorf("avro/generic: union branch %d is nil", i)
+		}
+		if _, nested := t.(avro.Union); nested {
+			return nil, fmt.Errorf("avro/generic: union branch %d is itself a union", i)
+		}
+		key, named := unionBranchKey(t)
+		if named {
+			if _, dup := seenNamed[key]; dup {
+				return nil, fmt.Errorf("avro/generic: union: duplicate named branch %q", key)
+			}
+			seenNamed[key] = struct{}{}
+		} else {
+			if _, dup := seenUnnamed[key]; dup {
+				return nil, fmt.Errorf("avro/generic: union: duplicate %s branch", key)
+			}
+			seenUnnamed[key] = struct{}{}
+		}
+		node, err := compileSchema(t, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("union branch %d: %w", i, err)
+		}
+		branches[i] = node
+	}
+	return &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			un, ok := v.(Union)
+			if !ok {
+				return typeMismatch("union", v)
+			}
+			if un.Index < 0 || un.Index >= len(branches) {
+				return fmt.Errorf("avro/generic: union: index %d out of range [0, %d)", un.Index, len(branches))
+			}
+			if err := w.WriteLong(int64(un.Index)); err != nil {
+				return err
+			}
+			return branches[un.Index].enc(w, un.Value)
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			i, err := r.ReadLong()
+			if err != nil {
+				return nil, err
+			}
+			if i < 0 || int(i) >= len(branches) {
+				return nil, fmt.Errorf("avro/generic: union: index %d out of range [0, %d)", i, len(branches))
+			}
+			val, err := branches[i].dec(r)
+			if err != nil {
+				return nil, err
+			}
+			return Union{Index: int(i), Value: val}, nil
+		},
+	}, nil
+}
+
+func unionBranchKey(s avro.Schema) (string, bool) {
+	switch t := s.(type) {
+	case avro.Null:
+		return "null", false
+	case avro.Boolean:
+		return "boolean", false
+	case avro.Int:
+		return "int", false
+	case avro.Long:
+		return "long", false
+	case avro.Float:
+		return "float", false
+	case avro.Double:
+		return "double", false
+	case avro.Bytes:
+		return "bytes", false
+	case avro.String:
+		return "string", false
+	case avro.Array:
+		return "array", false
+	case avro.Map:
+		return "map", false
+	case avro.Record:
+		return fullName(t.Name, t.Namespace), true
+	case avro.Enum:
+		return fullName(t.Name, t.Namespace), true
+	case avro.Fixed:
+		return fullName(t.Name, t.Namespace), true
+	case avro.Ref:
+		return fullName(t.Name, t.Namespace), true
+	default:
+		return fmt.Sprintf("%T", s), false
+	}
+}
+
+func compileFixed(f avro.Fixed, ctx *compileCtx) (*planNode, error) {
+	if f.Name == "" {
+		return nil, fmt.Errorf("avro/generic: fixed missing name")
+	}
+	if f.Size <= 0 {
+		return nil, fmt.Errorf("avro/generic: fixed %q: size must be > 0, got %d", f.Name, f.Size)
+	}
+	encPtr := new(encodeFn)
+	decPtr := new(decodeFn)
+	if err := ctx.registerNamed(f.Name, f.Namespace, &namedEntry{
+		kind: namedFixed, schema: f, enc: encPtr, dec: decPtr, size: f.Size,
+	}); err != nil {
+		return nil, err
+	}
+	name := f.Name
+	size := f.Size
+	*encPtr = func(w *avro.BinaryWriter, v Value) error {
+		fx, ok := v.(Fixed)
+		if !ok {
+			return typeMismatch(fmt.Sprintf("fixed %q", name), v)
+		}
+		if len(fx) != size {
+			return fmt.Errorf("avro/generic: fixed %q: expected %d bytes, got %d", name, size, len(fx))
+		}
+		return w.WriteFixed([]byte(fx))
+	}
+	*decPtr = func(r *avro.BinaryReader) (Value, error) {
+		b, err := r.ReadFixed(size)
+		if err != nil {
+			return nil, err
+		}
+		return Fixed(b), nil
+	}
+	return &planNode{enc: *encPtr, dec: *decPtr}, nil
+}
+
+// ---- logical type plans ----
+
+func compileDecimal(d avro.Decimal, _ *compileCtx) (*planNode, error) {
+	if d.Precision <= 0 {
+		return nil, fmt.Errorf("avro/generic: decimal: precision must be > 0, got %d", d.Precision)
+	}
+	if d.Scale < 0 || d.Scale > d.Precision {
+		return nil, fmt.Errorf("avro/generic: decimal: scale %d out of range [0, %d]", d.Scale, d.Precision)
+	}
+	switch under := d.Underlying.(type) {
+	case avro.Bytes:
+		precision := d.Precision
+		return &planNode{
+			enc: func(w *avro.BinaryWriter, v Value) error {
+				dec, ok := v.(Decimal)
+				if !ok {
+					return typeMismatch("decimal", v)
+				}
+				if dec.Unscaled == nil {
+					return fmt.Errorf("avro/generic: decimal: nil Unscaled")
+				}
+				if !decimalFits(dec.Unscaled, precision) {
+					return fmt.Errorf("avro/generic: decimal: value exceeds precision %d", precision)
+				}
+				return w.WriteBytes(twosComplementBytes(dec.Unscaled))
+			},
+			dec: func(r *avro.BinaryReader) (Value, error) {
+				b, err := r.ReadBytes()
+				if err != nil {
+					return nil, err
+				}
+				return Decimal{Unscaled: bytesToBigInt(b)}, nil
+			},
+		}, nil
+	case avro.Fixed:
+		if under.Size <= 0 {
+			return nil, fmt.Errorf("avro/generic: decimal: underlying fixed has invalid size %d", under.Size)
+		}
+		size := under.Size
+		precision := d.Precision
+		return &planNode{
+			enc: func(w *avro.BinaryWriter, v Value) error {
+				dec, ok := v.(Decimal)
+				if !ok {
+					return typeMismatch("decimal", v)
+				}
+				if dec.Unscaled == nil {
+					return fmt.Errorf("avro/generic: decimal: nil Unscaled")
+				}
+				if !decimalFits(dec.Unscaled, precision) {
+					return fmt.Errorf("avro/generic: decimal: value exceeds precision %d", precision)
+				}
+				b := twosComplementBytes(dec.Unscaled)
+				if len(b) > size {
+					return fmt.Errorf("avro/generic: decimal: encoded %d bytes exceeds fixed size %d", len(b), size)
+				}
+				return w.WriteFixed(padTwosComplement(b, size, dec.Unscaled.Sign()))
+			},
+			dec: func(r *avro.BinaryReader) (Value, error) {
+				b, err := r.ReadFixed(size)
+				if err != nil {
+					return nil, err
+				}
+				return Decimal{Unscaled: bytesToBigInt(b)}, nil
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("avro/generic: decimal: underlying must be bytes or fixed, got %T", d.Underlying)
+	}
+}
+
+var (
+	uuidPlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			u, ok := v.(UUID)
+			if !ok {
+				return typeMismatch("uuid", v)
+			}
+			return w.WriteString(string(u))
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			s, err := r.ReadString()
+			if err != nil {
+				return nil, err
+			}
+			return UUID(s), nil
+		},
+	}
+	datePlan = newIntLogical("date",
+		func(i int32) Value { return Date(i) },
+		func(v Value) (int32, bool) { x, ok := v.(Date); return int32(x), ok },
+	)
+	timeMillisPlan = newIntLogical("time-millis",
+		func(i int32) Value { return TimeMillis(i) },
+		func(v Value) (int32, bool) { x, ok := v.(TimeMillis); return int32(x), ok },
+	)
+	timeMicrosPlan = newLongLogical("time-micros",
+		func(l int64) Value { return TimeMicros(l) },
+		func(v Value) (int64, bool) { x, ok := v.(TimeMicros); return int64(x), ok },
+	)
+	timestampMillisPlan = newLongLogical("timestamp-millis",
+		func(l int64) Value { return TimestampMillis(l) },
+		func(v Value) (int64, bool) { x, ok := v.(TimestampMillis); return int64(x), ok },
+	)
+	timestampMicrosPlan = newLongLogical("timestamp-micros",
+		func(l int64) Value { return TimestampMicros(l) },
+		func(v Value) (int64, bool) { x, ok := v.(TimestampMicros); return int64(x), ok },
+	)
+	timestampNanosPlan = newLongLogical("timestamp-nanos",
+		func(l int64) Value { return TimestampNanos(l) },
+		func(v Value) (int64, bool) { x, ok := v.(TimestampNanos); return int64(x), ok },
+	)
+	localTimestampMillisPlan = newLongLogical("local-timestamp-millis",
+		func(l int64) Value { return LocalTimestampMillis(l) },
+		func(v Value) (int64, bool) { x, ok := v.(LocalTimestampMillis); return int64(x), ok },
+	)
+	localTimestampMicrosPlan = newLongLogical("local-timestamp-micros",
+		func(l int64) Value { return LocalTimestampMicros(l) },
+		func(v Value) (int64, bool) { x, ok := v.(LocalTimestampMicros); return int64(x), ok },
+	)
+	localTimestampNanosPlan = newLongLogical("local-timestamp-nanos",
+		func(l int64) Value { return LocalTimestampNanos(l) },
+		func(v Value) (int64, bool) { x, ok := v.(LocalTimestampNanos); return int64(x), ok },
+	)
+
+	durationPlan = &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			d, ok := v.(Duration)
+			if !ok {
+				return typeMismatch("duration", v)
+			}
+			var buf [12]byte
+			binary.LittleEndian.PutUint32(buf[0:4], d.Months)
+			binary.LittleEndian.PutUint32(buf[4:8], d.Days)
+			binary.LittleEndian.PutUint32(buf[8:12], d.Millis)
+			return w.WriteFixed(buf[:])
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			b, err := r.ReadFixed(12)
+			if err != nil {
+				return nil, err
+			}
+			return Duration{
+				Months: binary.LittleEndian.Uint32(b[0:4]),
+				Days:   binary.LittleEndian.Uint32(b[4:8]),
+				Millis: binary.LittleEndian.Uint32(b[8:12]),
+			}, nil
+		},
+	}
+)
+
+// newIntLogical builds a plan for an int-backed logical type. unwrap converts
+// a Value to its int32 wire form (returning ok=false on type mismatch); wrap
+// builds the Value back from a decoded int32.
+func newIntLogical(name string, wrap func(int32) Value, unwrap func(Value) (int32, bool)) *planNode {
+	return &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			i, ok := unwrap(v)
+			if !ok {
+				return typeMismatch(name, v)
+			}
+			return w.WriteInt(i)
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			i, err := r.ReadInt()
+			if err != nil {
+				return nil, err
+			}
+			return wrap(i), nil
+		},
+	}
+}
+
+// newLongLogical is the int64 counterpart of newIntLogical.
+func newLongLogical(name string, wrap func(int64) Value, unwrap func(Value) (int64, bool)) *planNode {
+	return &planNode{
+		enc: func(w *avro.BinaryWriter, v Value) error {
+			l, ok := unwrap(v)
+			if !ok {
+				return typeMismatch(name, v)
+			}
+			return w.WriteLong(l)
+		},
+		dec: func(r *avro.BinaryReader) (Value, error) {
+			l, err := r.ReadLong()
+			if err != nil {
+				return nil, err
+			}
+			return wrap(l), nil
+		},
+	}
+}
+
+// ---- helpers ----
+
+func typeMismatch(want string, got Value) error {
+	return fmt.Errorf("avro/generic: type mismatch: schema expects %s, got %T", want, got)
+}
+
+// twosComplementBytes returns the minimum-length two's-complement big-endian
+// byte representation of x, matching the Avro decimal wire format.
+func twosComplementBytes(x *big.Int) []byte {
+	if x.Sign() == 0 {
+		return []byte{0}
+	}
+	if x.Sign() > 0 {
+		b := x.Bytes()
+		if b[0]&0x80 != 0 {
+			return append([]byte{0x00}, b...)
+		}
+		return b
+	}
+	mag := new(big.Int).Neg(x)
+	bits := mag.BitLen()
+	byteLen := (bits + 7) / 8
+	if bits%8 == 0 {
+		byteLen++
+	}
+	mod := new(big.Int).Lsh(big.NewInt(1), uint(8*byteLen))
+	twos := new(big.Int).Sub(mod, mag)
+	out := make([]byte, byteLen)
+	tb := twos.Bytes()
+	copy(out[byteLen-len(tb):], tb)
+	return out
+}
+
+// bytesToBigInt is the inverse of twosComplementBytes.
+func bytesToBigInt(b []byte) *big.Int {
+	if len(b) == 0 {
+		return big.NewInt(0)
+	}
+	x := new(big.Int).SetBytes(b)
+	if b[0]&0x80 != 0 {
+		// Negative: subtract 2^(8*len).
+		mod := new(big.Int).Lsh(big.NewInt(1), uint(8*len(b)))
+		x.Sub(x, mod)
+	}
+	return x
+}
+
+func padTwosComplement(b []byte, size, sign int) []byte {
+	if len(b) == size {
+		return b
+	}
+	pad := byte(0x00)
+	if sign < 0 {
+		pad = 0xff
+	}
+	out := make([]byte, size)
+	for i := range out[:size-len(b)] {
+		out[i] = pad
+	}
+	copy(out[size-len(b):], b)
+	return out
+}
+
+func decimalFits(x *big.Int, precision int) bool {
+	limit := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+	abs := new(big.Int).Abs(x)
+	return abs.Cmp(limit) < 0
+}

--- a/generic/codec.go
+++ b/generic/codec.go
@@ -515,7 +515,7 @@ func compileUnion(u avro.Union, ctx *compileCtx) (*planNode, error) {
 			if err != nil {
 				return nil, err
 			}
-			if i < 0 || int(i) >= len(branches) {
+			if i < 0 || i >= int64(len(branches)) {
 				return nil, IndexOutOfRangeError{Kind: "union", Index: i, Len: len(branches)}
 			}
 			val, err := branches[i].dec(r)

--- a/generic/codec.go
+++ b/generic/codec.go
@@ -81,7 +81,7 @@ func compileSchema(s avro.Schema, ctx *compileCtx, namespace string) (*planNode,
 	case avro.LocalTimestampNanos:
 		return localTimestampNanosPlan, nil
 	case avro.Duration:
-		return durationPlan, nil
+		return compileDuration(t, ctx, namespace)
 	default:
 		return nil, UnsupportedSchemaError{Schema: s}
 	}
@@ -543,6 +543,11 @@ func compileUnion(u avro.Union, ctx *compileCtx, namespace string) (*planNode, e
 	}, nil
 }
 
+// unionBranchKey returns the Avro identity key for a union branch and whether
+// the key is for a named type. Per the Avro spec, a union may not contain two
+// schemas with the same wire type; logical types collapse to the identity of
+// their underlying schema so e.g. [int, date] or [bytes, decimal-over-bytes]
+// are correctly detected as duplicates.
 func unionBranchKey(s avro.Schema, namespace string) (string, bool) {
 	resolveNS := func(declared string) string {
 		if declared != "" {
@@ -579,6 +584,27 @@ func unionBranchKey(s avro.Schema, namespace string) (string, bool) {
 		return fullName(t.Name, resolveNS(t.Namespace)), true
 	case avro.Ref:
 		return fullName(t.Name, resolveNS(t.Namespace)), true
+	case avro.UUID:
+		return "string", false
+	case avro.Date, avro.TimeMillis:
+		return "int", false
+	case avro.TimeMicros,
+		avro.TimestampMillis, avro.TimestampMicros, avro.TimestampNanos,
+		avro.LocalTimestampMillis, avro.LocalTimestampMicros, avro.LocalTimestampNanos:
+		return "long", false
+	case avro.Decimal:
+		switch under := t.Underlying.(type) {
+		case avro.Fixed:
+			return fullName(under.Name, resolveNS(under.Namespace)), true
+		default:
+			return "bytes", false
+		}
+	case avro.Duration:
+		name := t.Underlying.Name
+		if name == "" {
+			name = "duration"
+		}
+		return fullName(name, resolveNS(t.Underlying.Namespace)), true
 	default:
 		return fmt.Sprintf("%T", s), false
 	}
@@ -768,31 +794,57 @@ var (
 		func(v Value) (int64, bool) { x, ok := v.(LocalTimestampNanos); return int64(x), ok },
 	)
 
-	durationPlan = &planNode{
-		enc: func(w *avro.BinaryWriter, v Value) error {
-			d, ok := v.(Duration)
-			if !ok {
-				return typeMismatch("duration", v)
-			}
-			var buf [12]byte
-			binary.LittleEndian.PutUint32(buf[0:4], d.Months)
-			binary.LittleEndian.PutUint32(buf[4:8], d.Days)
-			binary.LittleEndian.PutUint32(buf[8:12], d.Millis)
-			return w.WriteFixed(buf[:])
-		},
-		dec: func(r *avro.BinaryReader) (Value, error) {
-			b, err := r.ReadFixed(12)
-			if err != nil {
-				return nil, err
-			}
-			return Duration{
-				Months: binary.LittleEndian.Uint32(b[0:4]),
-				Days:   binary.LittleEndian.Uint32(b[4:8]),
-				Millis: binary.LittleEndian.Uint32(b[8:12]),
-			}, nil
-		},
-	}
 )
+
+// compileDuration validates an Avro duration schema and registers its
+// underlying Fixed name so Refs can resolve to the same plan, mirroring the
+// decimal-over-fixed pattern. An empty Underlying.Name defaults to "duration"
+// to match Duration.MarshalJSON's convention.
+func compileDuration(d avro.Duration, ctx *compileCtx, namespace string) (*planNode, error) {
+	under := d.Underlying
+	if under.Size != 0 && under.Size != 12 {
+		return nil, InvalidFixedSizeError{Name: under.Name, Size: under.Size}
+	}
+	name := under.Name
+	if name == "" {
+		name = "duration"
+	}
+	ns := under.Namespace
+	if ns == "" {
+		ns = namespace
+	}
+
+	encPtr := new(encodeFn)
+	decPtr := new(decodeFn)
+	if err := ctx.registerNamed(name, ns, &namedEntry{
+		kind: namedFixed, schema: d, enc: encPtr, dec: decPtr, size: 12,
+	}); err != nil {
+		return nil, err
+	}
+	*encPtr = func(w *avro.BinaryWriter, v Value) error {
+		dv, ok := v.(Duration)
+		if !ok {
+			return typeMismatch("duration", v)
+		}
+		var buf [12]byte
+		binary.LittleEndian.PutUint32(buf[0:4], dv.Months)
+		binary.LittleEndian.PutUint32(buf[4:8], dv.Days)
+		binary.LittleEndian.PutUint32(buf[8:12], dv.Millis)
+		return w.WriteFixed(buf[:])
+	}
+	*decPtr = func(r *avro.BinaryReader) (Value, error) {
+		b, err := r.ReadFixed(12)
+		if err != nil {
+			return nil, err
+		}
+		return Duration{
+			Months: binary.LittleEndian.Uint32(b[0:4]),
+			Days:   binary.LittleEndian.Uint32(b[4:8]),
+			Millis: binary.LittleEndian.Uint32(b[8:12]),
+		}, nil
+	}
+	return &planNode{enc: *encPtr, dec: *decPtr}, nil
+}
 
 // newIntLogical builds a plan for an int-backed logical type. unwrap converts
 // a Value to its int32 wire form (returning ok=false on type mismatch); wrap

--- a/generic/compile.go
+++ b/generic/compile.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/z5labs/avro-go"
+)
+
+// fullName returns the fully-qualified Avro name for a named type.
+func fullName(name, namespace string) string {
+	if name == "" {
+		return ""
+	}
+	if strings.Contains(name, ".") || namespace == "" {
+		return name
+	}
+	return namespace + "." + name
+}
+
+// namedKind tracks the kind of a registered named schema, used to validate
+// that Ref-references resolve to compatible types.
+type namedKind int
+
+const (
+	namedRecord namedKind = iota + 1
+	namedEnum
+	namedFixed
+)
+
+// namedEntry holds a compiled named-type entry. The encode/decode pointers are
+// late-bound so that recursive types can resolve their own references.
+type namedEntry struct {
+	kind   namedKind
+	schema avro.Schema
+	enc    *encodeFn
+	dec    *decodeFn
+	size   int // for Fixed
+	// For Enum: pre-built symbol → index lookup.
+	symbolIndex map[string]int
+	symbols     []string
+}
+
+// encodeFn / decodeFn are pointer-indirected so Ref nodes can be wired to a
+// late-resolved closure.
+type (
+	encodeFn func(w *avro.BinaryWriter, v Value) error
+	decodeFn func(r *avro.BinaryReader) (Value, error)
+)
+
+// compileCtx is shared state across schema compilation.
+type compileCtx struct {
+	named map[string]*namedEntry
+}
+
+func newCompileCtx() *compileCtx {
+	return &compileCtx{named: map[string]*namedEntry{}}
+}
+
+// resolveNamed returns the named entry for the fully-qualified name, or an
+// error if it has not been registered. Caller must use a pointer-deref pattern
+// when wiring encoders/decoders for Ref nodes so that recursive registrations
+// work.
+func (c *compileCtx) resolveNamed(name, namespace string) (*namedEntry, error) {
+	full := fullName(name, namespace)
+	entry, ok := c.named[full]
+	if !ok {
+		return nil, fmt.Errorf("avro/generic: unresolved reference %q", full)
+	}
+	return entry, nil
+}
+
+// registerNamed registers a named type. Returns an error if the name is
+// already registered.
+func (c *compileCtx) registerNamed(name, namespace string, entry *namedEntry) error {
+	full := fullName(name, namespace)
+	if full == "" {
+		return fmt.Errorf("avro/generic: named type missing name")
+	}
+	if _, exists := c.named[full]; exists {
+		return fmt.Errorf("avro/generic: duplicate named type %q", full)
+	}
+	c.named[full] = entry
+	return nil
+}

--- a/generic/compile.go
+++ b/generic/compile.go
@@ -6,7 +6,6 @@
 package generic
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/z5labs/avro-go"
@@ -70,7 +69,7 @@ func (c *compileCtx) resolveNamed(name, namespace string) (*namedEntry, error) {
 	full := fullName(name, namespace)
 	entry, ok := c.named[full]
 	if !ok {
-		return nil, fmt.Errorf("avro/generic: unresolved reference %q", full)
+		return nil, UnresolvedReferenceError{Name: full}
 	}
 	return entry, nil
 }
@@ -80,10 +79,10 @@ func (c *compileCtx) resolveNamed(name, namespace string) (*namedEntry, error) {
 func (c *compileCtx) registerNamed(name, namespace string, entry *namedEntry) error {
 	full := fullName(name, namespace)
 	if full == "" {
-		return fmt.Errorf("avro/generic: named type missing name")
+		return MissingNameError{Kind: "named type"}
 	}
 	if _, exists := c.named[full]; exists {
-		return fmt.Errorf("avro/generic: duplicate named type %q", full)
+		return DuplicateNameError{Name: full}
 	}
 	c.named[full] = entry
 	return nil

--- a/generic/decoder.go
+++ b/generic/decoder.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"fmt"
+
+	"github.com/z5labs/avro-go"
+)
+
+// Decoder decodes Avro binary data into generic Values using a compiled
+// avro.Schema.
+//
+// A Decoder is read-only after construction and is safe for concurrent use as
+// long as callers supply their own *avro.BinaryReader per call.
+type Decoder struct {
+	dec decodeFn
+}
+
+// NewDecoder validates s and returns a Decoder. Schema-level errors are
+// reported here, identical to NewEncoder.
+func NewDecoder(s avro.Schema) (*Decoder, error) {
+	if s == nil {
+		return nil, fmt.Errorf("avro/generic: nil schema")
+	}
+	node, err := compileSchema(s, newCompileCtx())
+	if err != nil {
+		return nil, err
+	}
+	return &Decoder{dec: node.dec}, nil
+}
+
+// Decode reads the next Value from r using the compiled schema.
+func (d *Decoder) Decode(r *avro.BinaryReader) (Value, error) {
+	return d.dec(r)
+}

--- a/generic/decoder.go
+++ b/generic/decoder.go
@@ -15,7 +15,7 @@ import (
 // avro.Schema.
 //
 // A Decoder is read-only after construction and is safe for concurrent use as
-// long as callers supply their own *avro.BinaryReader per call.
+// long as callers supply their own io.Reader per call.
 type Decoder struct {
 	dec decodeFn
 }

--- a/generic/decoder.go
+++ b/generic/decoder.go
@@ -7,6 +7,7 @@ package generic
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/z5labs/avro-go"
 )
@@ -34,6 +35,6 @@ func NewDecoder(s avro.Schema) (*Decoder, error) {
 }
 
 // Decode reads the next Value from r using the compiled schema.
-func (d *Decoder) Decode(r *avro.BinaryReader) (Value, error) {
-	return d.dec(r)
+func (d *Decoder) Decode(r io.Reader) (Value, error) {
+	return d.dec(avro.NewBinaryReader(r))
 }

--- a/generic/decoder.go
+++ b/generic/decoder.go
@@ -6,7 +6,6 @@
 package generic
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/z5labs/avro-go"
@@ -25,7 +24,7 @@ type Decoder struct {
 // reported here, identical to NewEncoder.
 func NewDecoder(s avro.Schema) (*Decoder, error) {
 	if s == nil {
-		return nil, fmt.Errorf("avro/generic: nil schema")
+		return nil, ErrNilSchema
 	}
 	node, err := compileSchema(s, newCompileCtx())
 	if err != nil {

--- a/generic/decoder.go
+++ b/generic/decoder.go
@@ -26,7 +26,7 @@ func NewDecoder(s avro.Schema) (*Decoder, error) {
 	if s == nil {
 		return nil, ErrNilSchema
 	}
-	node, err := compileSchema(s, newCompileCtx())
+	node, err := compileSchema(s, newCompileCtx(), "")
 	if err != nil {
 		return nil, err
 	}

--- a/generic/decoder_test.go
+++ b/generic/decoder_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/z5labs/avro-go"
+)
+
+// unmarshalAdapter routes the *avro.BinaryReader constructed by
+// avro.UnmarshalBinary into a Decoder, returning the decoded Value via the
+// captured pointers.
+type unmarshalAdapter struct {
+	dec *Decoder
+	out *Value
+}
+
+func (u unmarshalAdapter) UnmarshalAvroBinary(r *avro.BinaryReader) error {
+	v, err := u.dec.Decode(r)
+	if err != nil {
+		return err
+	}
+	*u.out = v
+	return nil
+}
+
+// decodeOne is a small helper that validates s, then decodes data into a
+// Value.
+func decodeOne(t *testing.T, s avro.Schema, data []byte) (Value, error) {
+	t.Helper()
+	dec, err := NewDecoder(s)
+	if err != nil {
+		return nil, err
+	}
+	var out Value
+	err = avro.UnmarshalBinary(bytes.NewReader(data), unmarshalAdapter{dec: dec, out: &out})
+	return out, err
+}
+
+func TestDecoder_Primitives(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		schema avro.Schema
+		data   []byte
+		want   Value
+	}{
+		{name: "null", schema: avro.Null{}, data: nil, want: Null{}},
+		{name: "boolean true", schema: avro.Boolean{}, data: []byte{0x01}, want: Bool(true)},
+		{name: "boolean false", schema: avro.Boolean{}, data: []byte{0x00}, want: Bool(false)},
+		{name: "int 1", schema: avro.Int{}, data: []byte{0x02}, want: Int(1)},
+		{name: "int -1", schema: avro.Int{}, data: []byte{0x01}, want: Int(-1)},
+		{name: "long 64", schema: avro.Long{}, data: []byte{0x80, 0x01}, want: Long(64)},
+		{name: "string abc", schema: avro.String{}, data: []byte{0x06, 'a', 'b', 'c'}, want: String("abc")},
+		{name: "bytes", schema: avro.Bytes{}, data: []byte{0x04, 0xde, 0xad}, want: Bytes{0xde, 0xad}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := decodeOne(t, tc.schema, tc.data)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDecoder_RuntimeErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("union index out of range", func(t *testing.T) {
+		t.Parallel()
+		_, err := decodeOne(t, avro.Union{Types: []avro.Schema{avro.Null{}, avro.Int{}}}, []byte{0x06})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("enum index out of range", func(t *testing.T) {
+		t.Parallel()
+		_, err := decodeOne(t, avro.Enum{Name: "E", Symbols: []string{"A", "B"}}, []byte{0x06})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "out of range")
+	})
+}

--- a/generic/decoder_test.go
+++ b/generic/decoder_test.go
@@ -13,23 +13,6 @@ import (
 	"github.com/z5labs/avro-go"
 )
 
-// unmarshalAdapter routes the *avro.BinaryReader constructed by
-// avro.UnmarshalBinary into a Decoder, returning the decoded Value via the
-// captured pointers.
-type unmarshalAdapter struct {
-	dec *Decoder
-	out *Value
-}
-
-func (u unmarshalAdapter) UnmarshalAvroBinary(r *avro.BinaryReader) error {
-	v, err := u.dec.Decode(r)
-	if err != nil {
-		return err
-	}
-	*u.out = v
-	return nil
-}
-
 // decodeOne is a small helper that validates s, then decodes data into a
 // Value.
 func decodeOne(t *testing.T, s avro.Schema, data []byte) (Value, error) {
@@ -38,9 +21,7 @@ func decodeOne(t *testing.T, s avro.Schema, data []byte) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	var out Value
-	err = avro.UnmarshalBinary(bytes.NewReader(data), unmarshalAdapter{dec: dec, out: &out})
-	return out, err
+	return dec.Decode(bytes.NewReader(data))
 }
 
 func TestDecoder_Primitives(t *testing.T) {

--- a/generic/decoder_test.go
+++ b/generic/decoder_test.go
@@ -59,14 +59,21 @@ func TestDecoder_RuntimeErrors(t *testing.T) {
 	t.Run("union index out of range", func(t *testing.T) {
 		t.Parallel()
 		_, err := decodeOne(t, avro.Union{Types: []avro.Schema{avro.Null{}, avro.Int{}}}, []byte{0x06})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "out of range")
+		var got IndexOutOfRangeError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "union", got.Kind)
+		require.Equal(t, int64(3), got.Index)
+		require.Equal(t, 2, got.Len)
 	})
 
 	t.Run("enum index out of range", func(t *testing.T) {
 		t.Parallel()
 		_, err := decodeOne(t, avro.Enum{Name: "E", Symbols: []string{"A", "B"}}, []byte{0x06})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "out of range")
+		var got IndexOutOfRangeError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "enum", got.Kind)
+		require.Equal(t, "E", got.Name)
+		require.Equal(t, int64(3), got.Index)
+		require.Equal(t, 2, got.Len)
 	})
 }

--- a/generic/doc.go
+++ b/generic/doc.go
@@ -15,5 +15,5 @@
 //
 // An Encoder or Decoder is read-only after construction and is safe for
 // concurrent use across goroutines as long as each call supplies its own
-// *avro.BinaryWriter or *avro.BinaryReader.
+// io.Writer or io.Reader.
 package generic

--- a/generic/doc.go
+++ b/generic/doc.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package generic provides schema-driven encoding and decoding of arbitrary
+// Avro values, similar to Java's GenericRecord/GenericData or protobuf's
+// dynamicpb.
+//
+// Values are constructed from the Value types in this package (Null, Bool,
+// Int, Long, Float, Double, Bytes, String, Record, Enum, Array, Map, Union,
+// Fixed, plus the twelve logical-type values) and do not carry their own
+// schema. The schema is supplied to NewEncoder or NewDecoder, which validate
+// it once and pre-compute lookup tables that every Encode/Decode call reuses.
+//
+// An Encoder or Decoder is read-only after construction and is safe for
+// concurrent use across goroutines as long as each call supplies its own
+// *avro.BinaryWriter or *avro.BinaryReader.
+package generic

--- a/generic/encoder.go
+++ b/generic/encoder.go
@@ -14,7 +14,7 @@ import (
 // Encoder encodes generic Values against a compiled avro.Schema.
 //
 // An Encoder is read-only after construction and is safe for concurrent use as
-// long as callers supply their own *avro.BinaryWriter per call.
+// long as callers supply their own io.Writer per call.
 type Encoder struct {
 	enc encodeFn
 }

--- a/generic/encoder.go
+++ b/generic/encoder.go
@@ -7,6 +7,7 @@ package generic
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/z5labs/avro-go"
 )
@@ -34,6 +35,6 @@ func NewEncoder(s avro.Schema) (*Encoder, error) {
 }
 
 // Encode writes v to w using the compiled schema.
-func (e *Encoder) Encode(w *avro.BinaryWriter, v Value) error {
-	return e.enc(w, v)
+func (e *Encoder) Encode(w io.Writer, v Value) error {
+	return e.enc(avro.NewBinaryWriter(w), v)
 }

--- a/generic/encoder.go
+++ b/generic/encoder.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"fmt"
+
+	"github.com/z5labs/avro-go"
+)
+
+// Encoder encodes generic Values against a compiled avro.Schema.
+//
+// An Encoder is read-only after construction and is safe for concurrent use as
+// long as callers supply their own *avro.BinaryWriter per call.
+type Encoder struct {
+	enc encodeFn
+}
+
+// NewEncoder validates s and returns an Encoder that encodes Values matching
+// it. Schema-level errors (unresolved Ref, duplicate field names, invalid
+// logical-type pairing, etc.) are reported here.
+func NewEncoder(s avro.Schema) (*Encoder, error) {
+	if s == nil {
+		return nil, fmt.Errorf("avro/generic: nil schema")
+	}
+	node, err := compileSchema(s, newCompileCtx())
+	if err != nil {
+		return nil, err
+	}
+	return &Encoder{enc: node.enc}, nil
+}
+
+// Encode writes v to w using the compiled schema.
+func (e *Encoder) Encode(w *avro.BinaryWriter, v Value) error {
+	return e.enc(w, v)
+}

--- a/generic/encoder.go
+++ b/generic/encoder.go
@@ -26,7 +26,7 @@ func NewEncoder(s avro.Schema) (*Encoder, error) {
 	if s == nil {
 		return nil, ErrNilSchema
 	}
-	node, err := compileSchema(s, newCompileCtx())
+	node, err := compileSchema(s, newCompileCtx(), "")
 	if err != nil {
 		return nil, err
 	}

--- a/generic/encoder.go
+++ b/generic/encoder.go
@@ -6,7 +6,6 @@
 package generic
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/z5labs/avro-go"
@@ -25,7 +24,7 @@ type Encoder struct {
 // logical-type pairing, etc.) are reported here.
 func NewEncoder(s avro.Schema) (*Encoder, error) {
 	if s == nil {
-		return nil, fmt.Errorf("avro/generic: nil schema")
+		return nil, ErrNilSchema
 	}
 	node, err := compileSchema(s, newCompileCtx())
 	if err != nil {

--- a/generic/encoder_test.go
+++ b/generic/encoder_test.go
@@ -1,0 +1,402 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/z5labs/avro-go"
+)
+
+// encodeBytesFor is a small helper that runs an Encoder against v and returns
+// the resulting wire bytes.
+func encodeBytesFor(t *testing.T, s avro.Schema, v Value) []byte {
+	t.Helper()
+	enc, err := NewEncoder(s)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, avro.MarshalBinary(&buf, marshalAdapter{enc: enc, v: v}))
+	return buf.Bytes()
+}
+
+// marshalAdapter lets us reuse avro.MarshalBinary, which always supplies a
+// fresh *BinaryWriter.
+type marshalAdapter struct {
+	enc *Encoder
+	v   Value
+}
+
+func (m marshalAdapter) MarshalAvroBinary(w *avro.BinaryWriter) error {
+	return m.enc.Encode(w, m.v)
+}
+
+func TestEncoder_Primitives(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		schema   avro.Schema
+		value    Value
+		expected []byte
+	}{
+		{name: "null", schema: avro.Null{}, value: Null{}, expected: nil},
+		{name: "boolean true", schema: avro.Boolean{}, value: Bool(true), expected: []byte{0x01}},
+		{name: "boolean false", schema: avro.Boolean{}, value: Bool(false), expected: []byte{0x00}},
+		{name: "int 0", schema: avro.Int{}, value: Int(0), expected: []byte{0x00}},
+		{name: "int 1", schema: avro.Int{}, value: Int(1), expected: []byte{0x02}},
+		{name: "int -1", schema: avro.Int{}, value: Int(-1), expected: []byte{0x01}},
+		{name: "long 64", schema: avro.Long{}, value: Long(64), expected: []byte{0x80, 0x01}},
+		{name: "string abc", schema: avro.String{}, value: String("abc"), expected: []byte{0x06, 'a', 'b', 'c'}},
+		{name: "bytes", schema: avro.Bytes{}, value: Bytes{0xde, 0xad}, expected: []byte{0x04, 0xde, 0xad}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := encodeBytesFor(t, tc.schema, tc.value)
+			if tc.expected == nil {
+				require.Empty(t, got)
+				return
+			}
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestEncoder_Record(t *testing.T) {
+	t.Parallel()
+
+	s := avro.Record{
+		Name: "User",
+		Fields: []*avro.Field{
+			{Name: "id", Type: avro.Long{}},
+			{Name: "name", Type: avro.String{}},
+		},
+	}
+	v := Record{Fields: []Field{
+		{Name: "id", Value: Long(1)},
+		{Name: "name", Value: String("ada")},
+	}}
+
+	got := encodeBytesFor(t, s, v)
+	require.Equal(t, []byte{0x02, 0x06, 'a', 'd', 'a'}, got)
+}
+
+func TestEncoder_Enum(t *testing.T) {
+	t.Parallel()
+
+	s := avro.Enum{Name: "Color", Symbols: []string{"RED", "GREEN", "BLUE"}}
+	got := encodeBytesFor(t, s, Enum{Symbol: "GREEN"})
+	require.Equal(t, []byte{0x02}, got)
+}
+
+func TestEncoder_Array(t *testing.T) {
+	t.Parallel()
+
+	s := avro.Array{Items: avro.Long{}}
+	got := encodeBytesFor(t, s, Array{Long(1), Long(2)})
+	// block of 2: zigzag count 4, items 0x02 0x04, terminator 0
+	require.Equal(t, []byte{0x04, 0x02, 0x04, 0x00}, got)
+
+	// empty array
+	got = encodeBytesFor(t, s, Array{})
+	require.Equal(t, []byte{0x00}, got)
+}
+
+func TestEncoder_Map(t *testing.T) {
+	t.Parallel()
+
+	s := avro.Map{Values: avro.Long{}}
+	got := encodeBytesFor(t, s, Map{"a": Long(1)})
+	require.Equal(t, []byte{0x02, 0x02, 'a', 0x02, 0x00}, got)
+
+	got = encodeBytesFor(t, s, Map{})
+	require.Equal(t, []byte{0x00}, got)
+}
+
+func TestEncoder_Union(t *testing.T) {
+	t.Parallel()
+
+	s := avro.Union{Types: []avro.Schema{avro.Null{}, avro.String{}}}
+	got := encodeBytesFor(t, s, Union{Index: 1, Value: String("x")})
+	require.Equal(t, []byte{0x02, 0x02, 'x'}, got)
+
+	got = encodeBytesFor(t, s, Union{Index: 0, Value: Null{}})
+	require.Equal(t, []byte{0x00}, got)
+}
+
+func TestEncoder_Fixed(t *testing.T) {
+	t.Parallel()
+
+	s := avro.Fixed{Name: "MD5", Size: 4}
+	got := encodeBytesFor(t, s, Fixed{0x01, 0x02, 0x03, 0x04})
+	require.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, got)
+}
+
+func TestEncoder_Logicals(t *testing.T) {
+	t.Parallel()
+
+	t.Run("date", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, []byte{0x02}, encodeBytesFor(t, avro.Date{}, Date(1)))
+	})
+	t.Run("uuid", func(t *testing.T) {
+		t.Parallel()
+		s := "00000000-0000-0000-0000-000000000000"
+		want := append([]byte{byte(len(s) << 1)}, []byte(s)...)
+		require.Equal(t, want, encodeBytesFor(t, avro.UUID{}, UUID(s)))
+	})
+	t.Run("decimal over bytes", func(t *testing.T) {
+		t.Parallel()
+		s := avro.Decimal{Precision: 9, Scale: 2, Underlying: avro.Bytes{}}
+		// 12345 -> 0x30 0x39, prepended with length 2 (zigzag 4 -> 0x04)
+		got := encodeBytesFor(t, s, Decimal{Unscaled: big.NewInt(12345)})
+		require.Equal(t, []byte{0x04, 0x30, 0x39}, got)
+	})
+	t.Run("decimal negative over bytes", func(t *testing.T) {
+		t.Parallel()
+		s := avro.Decimal{Precision: 9, Scale: 0, Underlying: avro.Bytes{}}
+		got := encodeBytesFor(t, s, Decimal{Unscaled: big.NewInt(-1)})
+		require.Equal(t, []byte{0x02, 0xff}, got)
+	})
+	t.Run("decimal over fixed", func(t *testing.T) {
+		t.Parallel()
+		s := avro.Decimal{Precision: 9, Scale: 2, Underlying: avro.Fixed{Name: "Dec", Size: 4}}
+		got := encodeBytesFor(t, s, Decimal{Unscaled: big.NewInt(1)})
+		require.Equal(t, []byte{0x00, 0x00, 0x00, 0x01}, got)
+	})
+	t.Run("duration", func(t *testing.T) {
+		t.Parallel()
+		got := encodeBytesFor(t, avro.Duration{}, Duration{Months: 1, Days: 2, Millis: 3})
+		require.Equal(t, []byte{
+			0x01, 0x00, 0x00, 0x00,
+			0x02, 0x00, 0x00, 0x00,
+			0x03, 0x00, 0x00, 0x00,
+		}, got)
+	})
+}
+
+func TestEncoder_Refs(t *testing.T) {
+	t.Parallel()
+
+	// A record that references itself: linked list.
+	rec := avro.Record{
+		Name: "Node",
+		Fields: []*avro.Field{
+			{Name: "v", Type: avro.Long{}},
+			{Name: "next", Type: avro.Union{Types: []avro.Schema{avro.Null{}, avro.Ref{Name: "Node"}}}},
+		},
+	}
+	v := Record{Fields: []Field{
+		{Name: "v", Value: Long(1)},
+		{Name: "next", Value: Union{Index: 1, Value: Record{Fields: []Field{
+			{Name: "v", Value: Long(2)},
+			{Name: "next", Value: Union{Index: 0, Value: Null{}}},
+		}}}},
+	}}
+	got := encodeBytesFor(t, rec, v)
+	// v=1, union 1 (Node), v=2, union 0 (null)
+	require.Equal(t, []byte{0x02, 0x02, 0x04, 0x00}, got)
+}
+
+// ---- compile-time rejection tests ----
+
+func TestNewEncoder_Errors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		schema avro.Schema
+		// substring expected in the error message
+		errSub string
+	}{
+		{
+			name:   "nil schema",
+			schema: nil,
+			errSub: "nil schema",
+		},
+		{
+			name:   "unresolved ref",
+			schema: avro.Ref{Name: "Missing"},
+			errSub: "unresolved reference",
+		},
+		{
+			name: "duplicate field names",
+			schema: avro.Record{
+				Name: "R",
+				Fields: []*avro.Field{
+					{Name: "x", Type: avro.Int{}},
+					{Name: "x", Type: avro.Int{}},
+				},
+			},
+			errSub: "duplicate field name",
+		},
+		{
+			name:   "enum with no symbols",
+			schema: avro.Enum{Name: "E"},
+			errSub: "no symbols",
+		},
+		{
+			name:   "enum default not in symbols",
+			schema: avro.Enum{Name: "E", Symbols: []string{"A"}, Default: "B"},
+			errSub: "default",
+		},
+		{
+			name:   "enum duplicate symbols",
+			schema: avro.Enum{Name: "E", Symbols: []string{"A", "A"}},
+			errSub: "duplicate symbol",
+		},
+		{
+			name:   "fixed zero size",
+			schema: avro.Fixed{Name: "F", Size: 0},
+			errSub: "size must be > 0",
+		},
+		{
+			name:   "union with nested union",
+			schema: avro.Union{Types: []avro.Schema{avro.Union{Types: []avro.Schema{avro.Int{}}}}},
+			errSub: "itself a union",
+		},
+		{
+			name:   "union duplicate unnamed",
+			schema: avro.Union{Types: []avro.Schema{avro.Int{}, avro.Int{}}},
+			errSub: "duplicate",
+		},
+		{
+			name:   "decimal invalid precision",
+			schema: avro.Decimal{Precision: 0, Scale: 0, Underlying: avro.Bytes{}},
+			errSub: "precision",
+		},
+		{
+			name:   "decimal invalid scale",
+			schema: avro.Decimal{Precision: 4, Scale: 5, Underlying: avro.Bytes{}},
+			errSub: "scale",
+		},
+		{
+			name:   "decimal wrong underlying",
+			schema: avro.Decimal{Precision: 4, Scale: 0, Underlying: avro.Int{}},
+			errSub: "underlying",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewEncoder(tc.schema)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errSub)
+		})
+	}
+}
+
+// ---- runtime rejection tests ----
+
+func TestEncode_RuntimeErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("primitive type mismatch", func(t *testing.T) {
+		t.Parallel()
+		enc, err := NewEncoder(avro.Int{})
+		require.NoError(t, err)
+		err = enc.Encode(&avro.BinaryWriter{}, String("nope"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "type mismatch")
+	})
+
+	t.Run("record field name mismatch", func(t *testing.T) {
+		t.Parallel()
+		enc, err := NewEncoder(avro.Record{
+			Name: "R",
+			Fields: []*avro.Field{
+				{Name: "a", Type: avro.Int{}},
+				{Name: "b", Type: avro.Int{}},
+			},
+		})
+		require.NoError(t, err)
+		var buf bytes.Buffer
+		err = avro.MarshalBinary(&buf, marshalAdapter{enc: enc, v: Record{Fields: []Field{
+			{Name: "a", Value: Int(1)},
+			{Name: "wrong", Value: Int(2)},
+		}}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected name")
+	})
+
+	t.Run("record wrong field count", func(t *testing.T) {
+		t.Parallel()
+		enc, err := NewEncoder(avro.Record{
+			Name: "R",
+			Fields: []*avro.Field{
+				{Name: "a", Type: avro.Int{}},
+				{Name: "b", Type: avro.Int{}},
+			},
+		})
+		require.NoError(t, err)
+		err = enc.Encode(&avro.BinaryWriter{}, Record{Fields: []Field{{Name: "a", Value: Int(1)}}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected 2 fields")
+	})
+
+	t.Run("union index out of range", func(t *testing.T) {
+		t.Parallel()
+		enc, err := NewEncoder(avro.Union{Types: []avro.Schema{avro.Null{}, avro.Int{}}})
+		require.NoError(t, err)
+		err = enc.Encode(&avro.BinaryWriter{}, Union{Index: 5, Value: Int(0)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("union branch type mismatch", func(t *testing.T) {
+		t.Parallel()
+		enc, err := NewEncoder(avro.Union{Types: []avro.Schema{avro.Null{}, avro.Int{}}})
+		require.NoError(t, err)
+		var buf bytes.Buffer
+		err = avro.MarshalBinary(&buf, marshalAdapter{enc: enc, v: Union{Index: 1, Value: String("x")}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "type mismatch")
+	})
+
+	t.Run("logical/non-logical mismatch", func(t *testing.T) {
+		t.Parallel()
+		// Encoding a generic.Date into an avro.Int schema is rejected because
+		// the schema's encoder expects a generic.Int.
+		enc, err := NewEncoder(avro.Int{})
+		require.NoError(t, err)
+		err = enc.Encode(&avro.BinaryWriter{}, Date(0))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "type mismatch")
+	})
+
+	t.Run("enum unknown symbol", func(t *testing.T) {
+		t.Parallel()
+		enc, err := NewEncoder(avro.Enum{Name: "E", Symbols: []string{"A", "B"}})
+		require.NoError(t, err)
+		err = enc.Encode(&avro.BinaryWriter{}, Enum{Symbol: "X"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not in schema")
+	})
+
+	t.Run("fixed size mismatch", func(t *testing.T) {
+		t.Parallel()
+		enc, err := NewEncoder(avro.Fixed{Name: "F", Size: 4})
+		require.NoError(t, err)
+		err = enc.Encode(&avro.BinaryWriter{}, Fixed{0x01, 0x02})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected 4 bytes")
+	})
+
+	t.Run("decimal precision overflow", func(t *testing.T) {
+		t.Parallel()
+		enc, err := NewEncoder(avro.Decimal{Precision: 4, Scale: 0, Underlying: avro.Bytes{}})
+		require.NoError(t, err)
+		// 10^4 exceeds 4 digits of precision.
+		err = enc.Encode(&avro.BinaryWriter{}, Decimal{Unscaled: big.NewInt(10000)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "precision")
+	})
+}

--- a/generic/encoder_test.go
+++ b/generic/encoder_test.go
@@ -21,19 +21,8 @@ func encodeBytesFor(t *testing.T, s avro.Schema, v Value) []byte {
 	enc, err := NewEncoder(s)
 	require.NoError(t, err)
 	var buf bytes.Buffer
-	require.NoError(t, avro.MarshalBinary(&buf, marshalAdapter{enc: enc, v: v}))
+	require.NoError(t, enc.Encode(&buf, v))
 	return buf.Bytes()
-}
-
-// marshalAdapter lets us reuse avro.MarshalBinary, which always supplies a
-// fresh *BinaryWriter.
-type marshalAdapter struct {
-	enc *Encoder
-	v   Value
-}
-
-func (m marshalAdapter) MarshalAvroBinary(w *avro.BinaryWriter) error {
-	return m.enc.Encode(w, m.v)
 }
 
 func TestEncoder_Primitives(t *testing.T) {
@@ -303,7 +292,7 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		t.Parallel()
 		enc, err := NewEncoder(avro.Int{})
 		require.NoError(t, err)
-		err = enc.Encode(&avro.BinaryWriter{}, String("nope"))
+		err = enc.Encode(&bytes.Buffer{}, String("nope"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "type mismatch")
 	})
@@ -319,10 +308,10 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		})
 		require.NoError(t, err)
 		var buf bytes.Buffer
-		err = avro.MarshalBinary(&buf, marshalAdapter{enc: enc, v: Record{Fields: []Field{
+		err = enc.Encode(&buf, Record{Fields: []Field{
 			{Name: "a", Value: Int(1)},
 			{Name: "wrong", Value: Int(2)},
-		}}})
+		}})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "expected name")
 	})
@@ -337,7 +326,7 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		err = enc.Encode(&avro.BinaryWriter{}, Record{Fields: []Field{{Name: "a", Value: Int(1)}}})
+		err = enc.Encode(&bytes.Buffer{}, Record{Fields: []Field{{Name: "a", Value: Int(1)}}})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "expected 2 fields")
 	})
@@ -346,7 +335,7 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		t.Parallel()
 		enc, err := NewEncoder(avro.Union{Types: []avro.Schema{avro.Null{}, avro.Int{}}})
 		require.NoError(t, err)
-		err = enc.Encode(&avro.BinaryWriter{}, Union{Index: 5, Value: Int(0)})
+		err = enc.Encode(&bytes.Buffer{}, Union{Index: 5, Value: Int(0)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "out of range")
 	})
@@ -356,7 +345,7 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		enc, err := NewEncoder(avro.Union{Types: []avro.Schema{avro.Null{}, avro.Int{}}})
 		require.NoError(t, err)
 		var buf bytes.Buffer
-		err = avro.MarshalBinary(&buf, marshalAdapter{enc: enc, v: Union{Index: 1, Value: String("x")}})
+		err = enc.Encode(&buf, Union{Index: 1, Value: String("x")})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "type mismatch")
 	})
@@ -367,7 +356,7 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		// the schema's encoder expects a generic.Int.
 		enc, err := NewEncoder(avro.Int{})
 		require.NoError(t, err)
-		err = enc.Encode(&avro.BinaryWriter{}, Date(0))
+		err = enc.Encode(&bytes.Buffer{}, Date(0))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "type mismatch")
 	})
@@ -376,7 +365,7 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		t.Parallel()
 		enc, err := NewEncoder(avro.Enum{Name: "E", Symbols: []string{"A", "B"}})
 		require.NoError(t, err)
-		err = enc.Encode(&avro.BinaryWriter{}, Enum{Symbol: "X"})
+		err = enc.Encode(&bytes.Buffer{}, Enum{Symbol: "X"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not in schema")
 	})
@@ -385,7 +374,7 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		t.Parallel()
 		enc, err := NewEncoder(avro.Fixed{Name: "F", Size: 4})
 		require.NoError(t, err)
-		err = enc.Encode(&avro.BinaryWriter{}, Fixed{0x01, 0x02})
+		err = enc.Encode(&bytes.Buffer{}, Fixed{0x01, 0x02})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "expected 4 bytes")
 	})
@@ -395,7 +384,7 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		enc, err := NewEncoder(avro.Decimal{Precision: 4, Scale: 0, Underlying: avro.Bytes{}})
 		require.NoError(t, err)
 		// 10^4 exceeds 4 digits of precision.
-		err = enc.Encode(&avro.BinaryWriter{}, Decimal{Unscaled: big.NewInt(10000)})
+		err = enc.Encode(&bytes.Buffer{}, Decimal{Unscaled: big.NewInt(10000)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "precision")
 	})

--- a/generic/encoder_test.go
+++ b/generic/encoder_test.go
@@ -202,18 +202,22 @@ func TestNewEncoder_Errors(t *testing.T) {
 	testCases := []struct {
 		name   string
 		schema avro.Schema
-		// substring expected in the error message
-		errSub string
+		// assert validates the returned error using errors.Is / errors.As.
+		assert func(t *testing.T, err error)
 	}{
 		{
 			name:   "nil schema",
 			schema: nil,
-			errSub: "nil schema",
+			assert: func(t *testing.T, err error) { require.ErrorIs(t, err, ErrNilSchema) },
 		},
 		{
 			name:   "unresolved ref",
 			schema: avro.Ref{Name: "Missing"},
-			errSub: "unresolved reference",
+			assert: func(t *testing.T, err error) {
+				var got UnresolvedReferenceError
+				require.ErrorAs(t, err, &got)
+				require.Equal(t, "Missing", got.Name)
+			},
 		},
 		{
 			name: "duplicate field names",
@@ -224,52 +228,93 @@ func TestNewEncoder_Errors(t *testing.T) {
 					{Name: "x", Type: avro.Int{}},
 				},
 			},
-			errSub: "duplicate field name",
+			assert: func(t *testing.T, err error) {
+				var got DuplicateFieldError
+				require.ErrorAs(t, err, &got)
+				require.Equal(t, "R", got.Record)
+				require.Equal(t, "x", got.Field)
+			},
 		},
 		{
 			name:   "enum with no symbols",
 			schema: avro.Enum{Name: "E"},
-			errSub: "no symbols",
+			assert: func(t *testing.T, err error) {
+				var got EmptySymbolsError
+				require.ErrorAs(t, err, &got)
+				require.Equal(t, "E", got.Enum)
+			},
 		},
 		{
 			name:   "enum default not in symbols",
 			schema: avro.Enum{Name: "E", Symbols: []string{"A"}, Default: "B"},
-			errSub: "default",
+			assert: func(t *testing.T, err error) {
+				var got InvalidEnumDefaultError
+				require.ErrorAs(t, err, &got)
+				require.Equal(t, "B", got.Default)
+			},
 		},
 		{
 			name:   "enum duplicate symbols",
 			schema: avro.Enum{Name: "E", Symbols: []string{"A", "A"}},
-			errSub: "duplicate symbol",
+			assert: func(t *testing.T, err error) {
+				var got DuplicateSymbolError
+				require.ErrorAs(t, err, &got)
+				require.Equal(t, "A", got.Symbol)
+			},
 		},
 		{
 			name:   "fixed zero size",
 			schema: avro.Fixed{Name: "F", Size: 0},
-			errSub: "size must be > 0",
+			assert: func(t *testing.T, err error) {
+				var got InvalidFixedSizeError
+				require.ErrorAs(t, err, &got)
+				require.Equal(t, "F", got.Name)
+				require.Equal(t, 0, got.Size)
+			},
 		},
 		{
 			name:   "union with nested union",
 			schema: avro.Union{Types: []avro.Schema{avro.Union{Types: []avro.Schema{avro.Int{}}}}},
-			errSub: "itself a union",
+			assert: func(t *testing.T, err error) {
+				var got NestedUnionError
+				require.ErrorAs(t, err, &got)
+				require.Equal(t, 0, got.Index)
+			},
 		},
 		{
 			name:   "union duplicate unnamed",
 			schema: avro.Union{Types: []avro.Schema{avro.Int{}, avro.Int{}}},
-			errSub: "duplicate",
+			assert: func(t *testing.T, err error) {
+				var got DuplicateBranchError
+				require.ErrorAs(t, err, &got)
+				require.False(t, got.Named)
+				require.Equal(t, "int", got.Key)
+			},
 		},
 		{
 			name:   "decimal invalid precision",
 			schema: avro.Decimal{Precision: 0, Scale: 0, Underlying: avro.Bytes{}},
-			errSub: "precision",
+			assert: func(t *testing.T, err error) {
+				var got InvalidPrecisionError
+				require.ErrorAs(t, err, &got)
+			},
 		},
 		{
 			name:   "decimal invalid scale",
 			schema: avro.Decimal{Precision: 4, Scale: 5, Underlying: avro.Bytes{}},
-			errSub: "scale",
+			assert: func(t *testing.T, err error) {
+				var got InvalidScaleError
+				require.ErrorAs(t, err, &got)
+				require.Equal(t, 5, got.Scale)
+			},
 		},
 		{
 			name:   "decimal wrong underlying",
 			schema: avro.Decimal{Precision: 4, Scale: 0, Underlying: avro.Int{}},
-			errSub: "underlying",
+			assert: func(t *testing.T, err error) {
+				var got InvalidDecimalUnderlyingError
+				require.ErrorAs(t, err, &got)
+			},
 		},
 	}
 
@@ -278,7 +323,7 @@ func TestNewEncoder_Errors(t *testing.T) {
 			t.Parallel()
 			_, err := NewEncoder(tc.schema)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.errSub)
+			tc.assert(t, err)
 		})
 	}
 }
@@ -293,8 +338,10 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		enc, err := NewEncoder(avro.Int{})
 		require.NoError(t, err)
 		err = enc.Encode(&bytes.Buffer{}, String("nope"))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "type mismatch")
+		var got TypeMismatchError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "int", got.Expected)
+		require.Equal(t, String("nope"), got.Got)
 	})
 
 	t.Run("record field name mismatch", func(t *testing.T) {
@@ -312,8 +359,12 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 			{Name: "a", Value: Int(1)},
 			{Name: "wrong", Value: Int(2)},
 		}})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "expected name")
+		var got FieldNameError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "R", got.Record)
+		require.Equal(t, 1, got.Index)
+		require.Equal(t, "b", got.Expected)
+		require.Equal(t, "wrong", got.Got)
 	})
 
 	t.Run("record wrong field count", func(t *testing.T) {
@@ -327,8 +378,10 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		})
 		require.NoError(t, err)
 		err = enc.Encode(&bytes.Buffer{}, Record{Fields: []Field{{Name: "a", Value: Int(1)}}})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "expected 2 fields")
+		var got FieldCountError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, 2, got.Expected)
+		require.Equal(t, 1, got.Got)
 	})
 
 	t.Run("union index out of range", func(t *testing.T) {
@@ -336,8 +389,11 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		enc, err := NewEncoder(avro.Union{Types: []avro.Schema{avro.Null{}, avro.Int{}}})
 		require.NoError(t, err)
 		err = enc.Encode(&bytes.Buffer{}, Union{Index: 5, Value: Int(0)})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "out of range")
+		var got IndexOutOfRangeError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "union", got.Kind)
+		require.Equal(t, int64(5), got.Index)
+		require.Equal(t, 2, got.Len)
 	})
 
 	t.Run("union branch type mismatch", func(t *testing.T) {
@@ -346,8 +402,8 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		require.NoError(t, err)
 		var buf bytes.Buffer
 		err = enc.Encode(&buf, Union{Index: 1, Value: String("x")})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "type mismatch")
+		var got TypeMismatchError
+		require.ErrorAs(t, err, &got)
 	})
 
 	t.Run("logical/non-logical mismatch", func(t *testing.T) {
@@ -357,8 +413,8 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		enc, err := NewEncoder(avro.Int{})
 		require.NoError(t, err)
 		err = enc.Encode(&bytes.Buffer{}, Date(0))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "type mismatch")
+		var got TypeMismatchError
+		require.ErrorAs(t, err, &got)
 	})
 
 	t.Run("enum unknown symbol", func(t *testing.T) {
@@ -366,8 +422,10 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		enc, err := NewEncoder(avro.Enum{Name: "E", Symbols: []string{"A", "B"}})
 		require.NoError(t, err)
 		err = enc.Encode(&bytes.Buffer{}, Enum{Symbol: "X"})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "not in schema")
+		var got UnknownSymbolError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "E", got.Enum)
+		require.Equal(t, "X", got.Symbol)
 	})
 
 	t.Run("fixed size mismatch", func(t *testing.T) {
@@ -375,8 +433,10 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		enc, err := NewEncoder(avro.Fixed{Name: "F", Size: 4})
 		require.NoError(t, err)
 		err = enc.Encode(&bytes.Buffer{}, Fixed{0x01, 0x02})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "expected 4 bytes")
+		var got FixedSizeError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, 4, got.Expected)
+		require.Equal(t, 2, got.Got)
 	})
 
 	t.Run("decimal precision overflow", func(t *testing.T) {
@@ -385,7 +445,8 @@ func TestEncode_RuntimeErrors(t *testing.T) {
 		require.NoError(t, err)
 		// 10^4 exceeds 4 digits of precision.
 		err = enc.Encode(&bytes.Buffer{}, Decimal{Unscaled: big.NewInt(10000)})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "precision")
+		var got PrecisionOverflowError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, 4, got.Precision)
 	})
 }

--- a/generic/errors.go
+++ b/generic/errors.go
@@ -1,0 +1,303 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/z5labs/avro-go"
+)
+
+// Sentinel errors for parameterless failures. They are returned directly so
+// callers can assert with errors.Is.
+var (
+	// ErrNilSchema is returned by NewEncoder and NewDecoder when given a nil
+	// schema.
+	ErrNilSchema = errors.New("avro/generic: nil schema")
+
+	// ErrEmptyUnion is returned when a Union schema declares no branches.
+	ErrEmptyUnion = errors.New("avro/generic: union has no branches")
+
+	// ErrNilArrayItems is returned when an Array schema's Items is nil.
+	ErrNilArrayItems = errors.New("avro/generic: array has nil items schema")
+
+	// ErrNilMapValues is returned when a Map schema's Values is nil.
+	ErrNilMapValues = errors.New("avro/generic: map has nil values schema")
+
+	// ErrNilDecimalUnscaled is returned when encoding a Decimal whose
+	// Unscaled big.Int pointer is nil.
+	ErrNilDecimalUnscaled = errors.New("avro/generic: decimal: nil Unscaled")
+)
+
+// ---- schema-level errors ----
+
+// UnsupportedSchemaError reports a schema implementation the codec does not
+// know how to compile.
+type UnsupportedSchemaError struct{ Schema avro.Schema }
+
+func (e UnsupportedSchemaError) Error() string {
+	return fmt.Sprintf("avro/generic: unsupported schema type %T", e.Schema)
+}
+
+// MissingNameError reports a named schema (record/enum/fixed/field) whose
+// Name field is empty. Kind names which named-type kind triggered the error.
+type MissingNameError struct{ Kind string }
+
+func (e MissingNameError) Error() string {
+	return fmt.Sprintf("avro/generic: %s missing name", e.Kind)
+}
+
+// DuplicateNameError reports two named schemas registered under the same
+// fully-qualified name.
+type DuplicateNameError struct{ Name string }
+
+func (e DuplicateNameError) Error() string {
+	return fmt.Sprintf("avro/generic: duplicate named type %q", e.Name)
+}
+
+// UnresolvedReferenceError reports a Ref that does not match any previously
+// registered named schema.
+type UnresolvedReferenceError struct{ Name string }
+
+func (e UnresolvedReferenceError) Error() string {
+	return fmt.Sprintf("avro/generic: unresolved reference %q", e.Name)
+}
+
+// DuplicateFieldError reports a record schema with two fields sharing a name.
+type DuplicateFieldError struct{ Record, Field string }
+
+func (e DuplicateFieldError) Error() string {
+	return fmt.Sprintf("avro/generic: record %q: duplicate field name %q", e.Record, e.Field)
+}
+
+// InvalidFieldError reports a malformed Field within a record schema (nil
+// pointer, empty Name, or nil Type).
+type InvalidFieldError struct {
+	Record string
+	Index  int
+	Field  string // empty when the entry was nil or unnamed
+	Reason string
+}
+
+func (e InvalidFieldError) Error() string {
+	if e.Field != "" {
+		return fmt.Sprintf("avro/generic: record %q: field %q: %s", e.Record, e.Field, e.Reason)
+	}
+	return fmt.Sprintf("avro/generic: record %q: field %d: %s", e.Record, e.Index, e.Reason)
+}
+
+// FieldCompileError wraps an error encountered while compiling a record
+// field's nested schema, preserving the underlying cause for errors.Is /
+// errors.As traversal.
+type FieldCompileError struct {
+	Record, Field string
+	Err           error
+}
+
+func (e FieldCompileError) Error() string {
+	return fmt.Sprintf("avro/generic: record %q field %q: %v", e.Record, e.Field, e.Err)
+}
+
+func (e FieldCompileError) Unwrap() error { return e.Err }
+
+// ItemsCompileError wraps an error from compiling an array's Items schema.
+type ItemsCompileError struct{ Err error }
+
+func (e ItemsCompileError) Error() string { return fmt.Sprintf("avro/generic: array items: %v", e.Err) }
+func (e ItemsCompileError) Unwrap() error { return e.Err }
+
+// ValuesCompileError wraps an error from compiling a map's Values schema.
+type ValuesCompileError struct{ Err error }
+
+func (e ValuesCompileError) Error() string { return fmt.Sprintf("avro/generic: map values: %v", e.Err) }
+func (e ValuesCompileError) Unwrap() error { return e.Err }
+
+// BranchCompileError wraps an error from compiling one branch of a union.
+type BranchCompileError struct {
+	Index int
+	Err   error
+}
+
+func (e BranchCompileError) Error() string {
+	return fmt.Sprintf("avro/generic: union branch %d: %v", e.Index, e.Err)
+}
+
+func (e BranchCompileError) Unwrap() error { return e.Err }
+
+// EmptySymbolsError reports an Enum schema with no symbols.
+type EmptySymbolsError struct{ Enum string }
+
+func (e EmptySymbolsError) Error() string {
+	return fmt.Sprintf("avro/generic: enum %q has no symbols", e.Enum)
+}
+
+// DuplicateSymbolError reports an Enum schema with two identical symbols.
+type DuplicateSymbolError struct{ Enum, Symbol string }
+
+func (e DuplicateSymbolError) Error() string {
+	return fmt.Sprintf("avro/generic: enum %q: duplicate symbol %q", e.Enum, e.Symbol)
+}
+
+// InvalidEnumDefaultError reports an Enum whose Default is not one of its
+// declared symbols.
+type InvalidEnumDefaultError struct{ Enum, Default string }
+
+func (e InvalidEnumDefaultError) Error() string {
+	return fmt.Sprintf("avro/generic: enum %q: default %q not in symbols", e.Enum, e.Default)
+}
+
+// InvalidFixedSizeError reports a Fixed schema with non-positive Size.
+type InvalidFixedSizeError struct {
+	Name string
+	Size int
+}
+
+func (e InvalidFixedSizeError) Error() string {
+	return fmt.Sprintf("avro/generic: fixed %q: size must be > 0, got %d", e.Name, e.Size)
+}
+
+// NilBranchError reports a nil schema in a Union's Types slice.
+type NilBranchError struct{ Index int }
+
+func (e NilBranchError) Error() string {
+	return fmt.Sprintf("avro/generic: union branch %d is nil", e.Index)
+}
+
+// NestedUnionError reports a Union containing a Union as one of its branches.
+type NestedUnionError struct{ Index int }
+
+func (e NestedUnionError) Error() string {
+	return fmt.Sprintf("avro/generic: union branch %d is itself a union", e.Index)
+}
+
+// DuplicateBranchError reports a Union with two branches that resolve to the
+// same key (same primitive type, or same fully-qualified named type). Named
+// reports whether the duplication is among named branches.
+type DuplicateBranchError struct {
+	Key   string
+	Named bool
+}
+
+func (e DuplicateBranchError) Error() string {
+	if e.Named {
+		return fmt.Sprintf("avro/generic: union: duplicate named branch %q", e.Key)
+	}
+	return fmt.Sprintf("avro/generic: union: duplicate %s branch", e.Key)
+}
+
+// InvalidPrecisionError reports a Decimal schema with non-positive Precision.
+type InvalidPrecisionError struct{ Precision int }
+
+func (e InvalidPrecisionError) Error() string {
+	return fmt.Sprintf("avro/generic: decimal: precision must be > 0, got %d", e.Precision)
+}
+
+// InvalidScaleError reports a Decimal schema with Scale outside [0, Precision].
+type InvalidScaleError struct{ Precision, Scale int }
+
+func (e InvalidScaleError) Error() string {
+	return fmt.Sprintf("avro/generic: decimal: scale %d out of range [0, %d]", e.Scale, e.Precision)
+}
+
+// InvalidDecimalUnderlyingError reports a Decimal whose Underlying schema is
+// neither Bytes nor Fixed.
+type InvalidDecimalUnderlyingError struct{ Underlying avro.Schema }
+
+func (e InvalidDecimalUnderlyingError) Error() string {
+	return fmt.Sprintf("avro/generic: decimal: underlying must be bytes or fixed, got %T", e.Underlying)
+}
+
+// ---- runtime errors ----
+
+// TypeMismatchError reports a Value whose Go type does not match the schema
+// position currently being encoded.
+type TypeMismatchError struct {
+	Expected string
+	Got      Value
+}
+
+func (e TypeMismatchError) Error() string {
+	return fmt.Sprintf("avro/generic: type mismatch: schema expects %s, got %T", e.Expected, e.Got)
+}
+
+// FieldCountError reports a Record value with a different number of fields
+// than the schema declared.
+type FieldCountError struct {
+	Record         string
+	Expected, Got  int
+}
+
+func (e FieldCountError) Error() string {
+	return fmt.Sprintf("avro/generic: record %q: expected %d fields, got %d", e.Record, e.Expected, e.Got)
+}
+
+// FieldNameError reports a Record value whose field name at Index does not
+// match the schema's field at the same position.
+type FieldNameError struct {
+	Record         string
+	Index          int
+	Expected, Got  string
+}
+
+func (e FieldNameError) Error() string {
+	return fmt.Sprintf("avro/generic: record %q: field %d: expected name %q, got %q", e.Record, e.Index, e.Expected, e.Got)
+}
+
+// IndexOutOfRangeError reports a Union or Enum index that falls outside the
+// schema's range. Kind is "union" or "enum"; Name is set for enums (whose
+// schema is named) and empty for unions.
+type IndexOutOfRangeError struct {
+	Kind  string
+	Name  string
+	Index int64
+	Len   int
+}
+
+func (e IndexOutOfRangeError) Error() string {
+	if e.Name != "" {
+		return fmt.Sprintf("avro/generic: %s %q: index %d out of range [0, %d)", e.Kind, e.Name, e.Index, e.Len)
+	}
+	return fmt.Sprintf("avro/generic: %s: index %d out of range [0, %d)", e.Kind, e.Index, e.Len)
+}
+
+// UnknownSymbolError reports an Enum value whose Symbol is not one of the
+// schema's declared symbols.
+type UnknownSymbolError struct{ Enum, Symbol string }
+
+func (e UnknownSymbolError) Error() string {
+	return fmt.Sprintf("avro/generic: enum %q: symbol %q not in schema", e.Enum, e.Symbol)
+}
+
+// FixedSizeError reports a Fixed value whose byte length does not match the
+// schema's Size.
+type FixedSizeError struct {
+	Name           string
+	Expected, Got  int
+}
+
+func (e FixedSizeError) Error() string {
+	return fmt.Sprintf("avro/generic: fixed %q: expected %d bytes, got %d", e.Name, e.Expected, e.Got)
+}
+
+// PrecisionOverflowError reports a Decimal value whose magnitude exceeds the
+// schema's Precision digit budget.
+type PrecisionOverflowError struct{ Precision int }
+
+func (e PrecisionOverflowError) Error() string {
+	return fmt.Sprintf("avro/generic: decimal: value exceeds precision %d", e.Precision)
+}
+
+// DecimalSizeError reports a Decimal whose two's-complement encoding does
+// not fit in a fixed-backed schema's byte size.
+type DecimalSizeError struct {
+	Encoded   int
+	FixedSize int
+}
+
+func (e DecimalSizeError) Error() string {
+	return fmt.Sprintf("avro/generic: decimal: encoded %d bytes exceeds fixed size %d", e.Encoded, e.FixedSize)
+}

--- a/generic/errors.go
+++ b/generic/errors.go
@@ -160,6 +160,14 @@ func (e InvalidFixedSizeError) Error() string {
 	return fmt.Sprintf("avro/generic: fixed %q: size must be > 0, got %d", e.Name, e.Size)
 }
 
+// InvalidDurationSizeError reports a Duration schema whose Underlying.Size
+// is set to a value other than 12 (the size required by the Avro spec).
+type InvalidDurationSizeError struct{ Size int }
+
+func (e InvalidDurationSizeError) Error() string {
+	return fmt.Sprintf("avro/generic: duration: underlying size must be 12, got %d", e.Size)
+}
+
 // NilBranchError reports a nil schema in a Union's Types slice.
 type NilBranchError struct{ Index int }
 

--- a/generic/example_test.go
+++ b/generic/example_test.go
@@ -3,7 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-package generic_test
+package generic
 
 import (
 	"bytes"
@@ -11,27 +11,26 @@ import (
 	"fmt"
 
 	"github.com/z5labs/avro-go"
-	"github.com/z5labs/avro-go/generic"
 )
 
-// schemaWriter adapts an *Encoder/Value pair to avro.BinaryMarshaler so it can
-// be passed to avro.MarshalBinary.
-type schemaWriter struct {
-	enc *generic.Encoder
-	v   generic.Value
+// exampleWriter adapts an *Encoder/Value pair to avro.BinaryMarshaler so it
+// can be passed to avro.MarshalBinary.
+type exampleWriter struct {
+	enc *Encoder
+	v   Value
 }
 
-func (s schemaWriter) MarshalAvroBinary(w *avro.BinaryWriter) error {
+func (s exampleWriter) MarshalAvroBinary(w *avro.BinaryWriter) error {
 	return s.enc.Encode(w, s.v)
 }
 
-// schemaReader adapts a *Decoder to avro.BinaryUnmarshaler.
-type schemaReader struct {
-	dec *generic.Decoder
-	out *generic.Value
+// exampleReader adapts a *Decoder to avro.BinaryUnmarshaler.
+type exampleReader struct {
+	dec *Decoder
+	out *Value
 }
 
-func (s schemaReader) UnmarshalAvroBinary(r *avro.BinaryReader) error {
+func (s exampleReader) UnmarshalAvroBinary(r *avro.BinaryReader) error {
 	v, err := s.dec.Decode(r)
 	if err != nil {
 		return err
@@ -50,19 +49,19 @@ func ExampleEncoder() {
 		},
 	}
 
-	enc, err := generic.NewEncoder(schema)
+	enc, err := NewEncoder(schema)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	user := generic.Record{Fields: []generic.Field{
-		{Name: "id", Value: generic.Long(1)},
-		{Name: "name", Value: generic.String("ada")},
+	user := Record{Fields: []Field{
+		{Name: "id", Value: Long(1)},
+		{Name: "name", Value: String("ada")},
 	}}
 
 	var buf bytes.Buffer
-	if err := avro.MarshalBinary(&buf, schemaWriter{enc: enc, v: user}); err != nil {
+	if err := avro.MarshalBinary(&buf, exampleWriter{enc: enc, v: user}); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -75,7 +74,7 @@ func ExampleEncoder() {
 // ExampleDecoder shows the canonical "decode a union" flow.
 func ExampleDecoder() {
 	schema := avro.Union{Types: []avro.Schema{avro.Null{}, avro.String{}}}
-	dec, err := generic.NewDecoder(schema)
+	dec, err := NewDecoder(schema)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -84,14 +83,14 @@ func ExampleDecoder() {
 	// Wire bytes for union index 1 + string "hi".
 	data := []byte{0x02, 0x04, 'h', 'i'}
 
-	var v generic.Value
-	if err := avro.UnmarshalBinary(bytes.NewReader(data), schemaReader{dec: dec, out: &v}); err != nil {
+	var v Value
+	if err := avro.UnmarshalBinary(bytes.NewReader(data), exampleReader{dec: dec, out: &v}); err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	u := v.(generic.Union)
-	fmt.Printf("index=%d value=%q\n", u.Index, string(u.Value.(generic.String)))
+	u := v.(Union)
+	fmt.Printf("index=%d value=%q\n", u.Index, string(u.Value.(String)))
 	// Output: index=1 value="hi"
 }
 
@@ -105,21 +104,21 @@ func ExampleEncoder_reuse() {
 			{Name: "y", Type: avro.Long{}},
 		},
 	}
-	enc, err := generic.NewEncoder(schema)
+	enc, err := NewEncoder(schema)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	points := []generic.Record{
-		{Fields: []generic.Field{{Name: "x", Value: generic.Long(0)}, {Name: "y", Value: generic.Long(0)}}},
-		{Fields: []generic.Field{{Name: "x", Value: generic.Long(1)}, {Name: "y", Value: generic.Long(2)}}},
-		{Fields: []generic.Field{{Name: "x", Value: generic.Long(3)}, {Name: "y", Value: generic.Long(4)}}},
+	points := []Record{
+		{Fields: []Field{{Name: "x", Value: Long(0)}, {Name: "y", Value: Long(0)}}},
+		{Fields: []Field{{Name: "x", Value: Long(1)}, {Name: "y", Value: Long(2)}}},
+		{Fields: []Field{{Name: "x", Value: Long(3)}, {Name: "y", Value: Long(4)}}},
 	}
 
 	var buf bytes.Buffer
 	for _, p := range points {
-		if err := avro.MarshalBinary(&buf, schemaWriter{enc: enc, v: p}); err != nil {
+		if err := avro.MarshalBinary(&buf, exampleWriter{enc: enc, v: p}); err != nil {
 			fmt.Println(err)
 			return
 		}

--- a/generic/example_test.go
+++ b/generic/example_test.go
@@ -13,32 +13,6 @@ import (
 	"github.com/z5labs/avro-go"
 )
 
-// exampleWriter adapts an *Encoder/Value pair to avro.BinaryMarshaler so it
-// can be passed to avro.MarshalBinary.
-type exampleWriter struct {
-	enc *Encoder
-	v   Value
-}
-
-func (s exampleWriter) MarshalAvroBinary(w *avro.BinaryWriter) error {
-	return s.enc.Encode(w, s.v)
-}
-
-// exampleReader adapts a *Decoder to avro.BinaryUnmarshaler.
-type exampleReader struct {
-	dec *Decoder
-	out *Value
-}
-
-func (s exampleReader) UnmarshalAvroBinary(r *avro.BinaryReader) error {
-	v, err := s.dec.Decode(r)
-	if err != nil {
-		return err
-	}
-	*s.out = v
-	return nil
-}
-
 // ExampleEncoder shows the canonical "encode a record" flow against a schema.
 func ExampleEncoder() {
 	schema := avro.Record{
@@ -61,7 +35,7 @@ func ExampleEncoder() {
 	}}
 
 	var buf bytes.Buffer
-	if err := avro.MarshalBinary(&buf, exampleWriter{enc: enc, v: user}); err != nil {
+	if err := enc.Encode(&buf, user); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -83,8 +57,8 @@ func ExampleDecoder() {
 	// Wire bytes for union index 1 + string "hi".
 	data := []byte{0x02, 0x04, 'h', 'i'}
 
-	var v Value
-	if err := avro.UnmarshalBinary(bytes.NewReader(data), exampleReader{dec: dec, out: &v}); err != nil {
+	v, err := dec.Decode(bytes.NewReader(data))
+	if err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -118,7 +92,7 @@ func ExampleEncoder_reuse() {
 
 	var buf bytes.Buffer
 	for _, p := range points {
-		if err := avro.MarshalBinary(&buf, exampleWriter{enc: enc, v: p}); err != nil {
+		if err := enc.Encode(&buf, p); err != nil {
 			fmt.Println(err)
 			return
 		}

--- a/generic/example_test.go
+++ b/generic/example_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/z5labs/avro-go"
+	"github.com/z5labs/avro-go/generic"
+)
+
+// schemaWriter adapts an *Encoder/Value pair to avro.BinaryMarshaler so it can
+// be passed to avro.MarshalBinary.
+type schemaWriter struct {
+	enc *generic.Encoder
+	v   generic.Value
+}
+
+func (s schemaWriter) MarshalAvroBinary(w *avro.BinaryWriter) error {
+	return s.enc.Encode(w, s.v)
+}
+
+// schemaReader adapts a *Decoder to avro.BinaryUnmarshaler.
+type schemaReader struct {
+	dec *generic.Decoder
+	out *generic.Value
+}
+
+func (s schemaReader) UnmarshalAvroBinary(r *avro.BinaryReader) error {
+	v, err := s.dec.Decode(r)
+	if err != nil {
+		return err
+	}
+	*s.out = v
+	return nil
+}
+
+// ExampleEncoder shows the canonical "encode a record" flow against a schema.
+func ExampleEncoder() {
+	schema := avro.Record{
+		Name: "User",
+		Fields: []*avro.Field{
+			{Name: "id", Type: avro.Long{}},
+			{Name: "name", Type: avro.String{}},
+		},
+	}
+
+	enc, err := generic.NewEncoder(schema)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	user := generic.Record{Fields: []generic.Field{
+		{Name: "id", Value: generic.Long(1)},
+		{Name: "name", Value: generic.String("ada")},
+	}}
+
+	var buf bytes.Buffer
+	if err := avro.MarshalBinary(&buf, schemaWriter{enc: enc, v: user}); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Print(hex.Dump(buf.Bytes()))
+	// Output:
+	// 00000000  02 06 61 64 61                                    |..ada|
+}
+
+// ExampleDecoder shows the canonical "decode a union" flow.
+func ExampleDecoder() {
+	schema := avro.Union{Types: []avro.Schema{avro.Null{}, avro.String{}}}
+	dec, err := generic.NewDecoder(schema)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Wire bytes for union index 1 + string "hi".
+	data := []byte{0x02, 0x04, 'h', 'i'}
+
+	var v generic.Value
+	if err := avro.UnmarshalBinary(bytes.NewReader(data), schemaReader{dec: dec, out: &v}); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	u := v.(generic.Union)
+	fmt.Printf("index=%d value=%q\n", u.Index, string(u.Value.(generic.String)))
+	// Output: index=1 value="hi"
+}
+
+// ExampleEncoder_reuse shows that one Encoder can be reused across many
+// records — the schema-validation cost is paid once.
+func ExampleEncoder_reuse() {
+	schema := avro.Record{
+		Name: "Point",
+		Fields: []*avro.Field{
+			{Name: "x", Type: avro.Long{}},
+			{Name: "y", Type: avro.Long{}},
+		},
+	}
+	enc, err := generic.NewEncoder(schema)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	points := []generic.Record{
+		{Fields: []generic.Field{{Name: "x", Value: generic.Long(0)}, {Name: "y", Value: generic.Long(0)}}},
+		{Fields: []generic.Field{{Name: "x", Value: generic.Long(1)}, {Name: "y", Value: generic.Long(2)}}},
+		{Fields: []generic.Field{{Name: "x", Value: generic.Long(3)}, {Name: "y", Value: generic.Long(4)}}},
+	}
+
+	var buf bytes.Buffer
+	for _, p := range points {
+		if err := avro.MarshalBinary(&buf, schemaWriter{enc: enc, v: p}); err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+
+	fmt.Println(buf.Len(), "bytes,", len(points), "records, single Encoder")
+	// Output: 6 bytes, 3 records, single Encoder
+}

--- a/generic/generic.go
+++ b/generic/generic.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package generic provides Avro values that can be encoded and decoded at
+// runtime using only an avro.Schema, without defining a Go struct per record.
+//
+// Values do not carry their schema; the schema is supplied to NewEncoder and
+// NewDecoder and all validation is performed there.
+package generic
+
+import "math/big"
+
+// Value is the interface implemented by all generic Avro values. The marker
+// method is unexported so the type set is closed to this package.
+type Value interface {
+	value()
+}
+
+// Null is the Avro null value.
+type Null struct{}
+
+func (Null) value() {}
+
+// Bool is the Avro boolean value.
+type Bool bool
+
+func (Bool) value() {}
+
+// Int is the Avro 32-bit integer value.
+type Int int32
+
+func (Int) value() {}
+
+// Long is the Avro 64-bit integer value.
+type Long int64
+
+func (Long) value() {}
+
+// Float is the Avro 32-bit float value.
+type Float float32
+
+func (Float) value() {}
+
+// Double is the Avro 64-bit float value.
+type Double float64
+
+func (Double) value() {}
+
+// Bytes is the Avro variable-length byte sequence value.
+type Bytes []byte
+
+func (Bytes) value() {}
+
+// String is the Avro string value.
+type String string
+
+func (String) value() {}
+
+// Field is a single named field within a Record value.
+type Field struct {
+	Name  string
+	Value Value
+}
+
+// Record is the Avro record value. Field order must match the schema's field
+// order at encode time.
+type Record struct {
+	Fields []Field
+}
+
+func (Record) value() {}
+
+// Enum is the Avro enum value.
+type Enum struct {
+	Symbol string
+}
+
+func (Enum) value() {}
+
+// Array is the Avro array value.
+type Array []Value
+
+func (Array) value() {}
+
+// Map is the Avro map value.
+type Map map[string]Value
+
+func (Map) value() {}
+
+// Union is the Avro union value. Index selects the branch in the union
+// schema's Types slice.
+type Union struct {
+	Index int
+	Value Value
+}
+
+func (Union) value() {}
+
+// Fixed is the Avro fixed-length byte sequence value.
+type Fixed []byte
+
+func (Fixed) value() {}
+
+// Decimal is the Avro "decimal" logical-type value. Unscaled holds the
+// unscaled integer; the scale is supplied by the schema.
+type Decimal struct {
+	Unscaled *big.Int
+}
+
+func (Decimal) value() {}
+
+// UUID is the Avro "uuid" logical-type value (RFC 4122 textual form).
+type UUID string
+
+func (UUID) value() {}
+
+// Date is the Avro "date" logical-type value: days since the Unix epoch.
+type Date int32
+
+func (Date) value() {}
+
+// TimeMillis is the Avro "time-millis" logical-type value: milliseconds after
+// midnight.
+type TimeMillis int32
+
+func (TimeMillis) value() {}
+
+// TimeMicros is the Avro "time-micros" logical-type value: microseconds after
+// midnight.
+type TimeMicros int64
+
+func (TimeMicros) value() {}
+
+// TimestampMillis is the Avro "timestamp-millis" logical-type value:
+// milliseconds since the Unix epoch in UTC.
+type TimestampMillis int64
+
+func (TimestampMillis) value() {}
+
+// TimestampMicros is the Avro "timestamp-micros" logical-type value:
+// microseconds since the Unix epoch in UTC.
+type TimestampMicros int64
+
+func (TimestampMicros) value() {}
+
+// TimestampNanos is the Avro "timestamp-nanos" logical-type value:
+// nanoseconds since the Unix epoch in UTC.
+type TimestampNanos int64
+
+func (TimestampNanos) value() {}
+
+// LocalTimestampMillis is the Avro "local-timestamp-millis" logical-type
+// value.
+type LocalTimestampMillis int64
+
+func (LocalTimestampMillis) value() {}
+
+// LocalTimestampMicros is the Avro "local-timestamp-micros" logical-type
+// value.
+type LocalTimestampMicros int64
+
+func (LocalTimestampMicros) value() {}
+
+// LocalTimestampNanos is the Avro "local-timestamp-nanos" logical-type value.
+type LocalTimestampNanos int64
+
+func (LocalTimestampNanos) value() {}
+
+// Duration is the Avro "duration" logical-type value. The wire form is three
+// little-endian unsigned 32-bit integers: months, days, and milliseconds.
+type Duration struct {
+	Months uint32
+	Days   uint32
+	Millis uint32
+}
+
+func (Duration) value() {}

--- a/generic/generic_test.go
+++ b/generic/generic_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueInterface(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		val  Value
+	}{
+		{name: "null", val: Null{}},
+		{name: "bool", val: Bool(true)},
+		{name: "int", val: Int(1)},
+		{name: "long", val: Long(1)},
+		{name: "float", val: Float(1)},
+		{name: "double", val: Double(1)},
+		{name: "bytes", val: Bytes{0x01}},
+		{name: "string", val: String("a")},
+		{name: "record", val: Record{Fields: []Field{{Name: "a", Value: Int(1)}}}},
+		{name: "enum", val: Enum{Symbol: "X"}},
+		{name: "array", val: Array{Int(1), Int(2)}},
+		{name: "map", val: Map{"k": Long(2)}},
+		{name: "union", val: Union{Index: 1, Value: String("v")}},
+		{name: "fixed", val: Fixed{0x01, 0x02, 0x03, 0x04}},
+		{name: "decimal", val: Decimal{Unscaled: big.NewInt(123)}},
+		{name: "uuid", val: UUID("00000000-0000-0000-0000-000000000000")},
+		{name: "date", val: Date(0)},
+		{name: "time millis", val: TimeMillis(0)},
+		{name: "time micros", val: TimeMicros(0)},
+		{name: "timestamp millis", val: TimestampMillis(0)},
+		{name: "timestamp micros", val: TimestampMicros(0)},
+		{name: "timestamp nanos", val: TimestampNanos(0)},
+		{name: "local timestamp millis", val: LocalTimestampMillis(0)},
+		{name: "local timestamp micros", val: LocalTimestampMicros(0)},
+		{name: "local timestamp nanos", val: LocalTimestampNanos(0)},
+		{name: "duration", val: Duration{Months: 1, Days: 2, Millis: 3}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.NotNil(t, tc.val)
+		})
+	}
+}

--- a/generic/roundtrip_test.go
+++ b/generic/roundtrip_test.go
@@ -198,6 +198,73 @@ func TestRoundTrip_RefInheritsEnclosingNamespace(t *testing.T) {
 	require.Equal(t, v, got)
 }
 
+// TestRoundTrip_DurationRefReuse verifies that a duration registers its
+// underlying fixed name so a Ref to that name resolves to the same duration
+// plan, mirroring decimal-over-fixed.
+func TestRoundTrip_DurationRefReuse(t *testing.T) {
+	t.Parallel()
+
+	dur := avro.Duration{Underlying: avro.Fixed{Name: "Elapsed", Namespace: "com.example", Size: 12}}
+	schema := avro.Record{
+		Name:      "Window",
+		Namespace: "com.example",
+		Fields: []*avro.Field{
+			{Name: "first", Type: dur},
+			{Name: "second", Type: avro.Ref{Name: "Elapsed"}},
+		},
+	}
+	v := Record{Fields: []Field{
+		{Name: "first", Value: Duration{Months: 1, Days: 2, Millis: 3}},
+		{Name: "second", Value: Duration{Months: 4, Days: 5, Millis: 6}},
+	}}
+	got := roundTrip(t, schema, v)
+	require.Equal(t, v, got)
+}
+
+// TestNewEncoder_DuplicateLogicalBranches checks that a union containing two
+// branches that share the same wire type (logical or not) is rejected per the
+// Avro spec rule "no duplicate types in a union".
+func TestNewEncoder_DuplicateLogicalBranches(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		schema avro.Schema
+		key    string
+	}{
+		{
+			name:   "int and date",
+			schema: avro.Union{Types: []avro.Schema{avro.Int{}, avro.Date{}}},
+			key:    "int",
+		},
+		{
+			name:   "string and uuid",
+			schema: avro.Union{Types: []avro.Schema{avro.String{}, avro.UUID{}}},
+			key:    "string",
+		},
+		{
+			name:   "long and timestamp-millis",
+			schema: avro.Union{Types: []avro.Schema{avro.Long{}, avro.TimestampMillis{}}},
+			key:    "long",
+		},
+		{
+			name:   "bytes and decimal-over-bytes",
+			schema: avro.Union{Types: []avro.Schema{avro.Bytes{}, avro.Decimal{Precision: 4, Underlying: avro.Bytes{}}}},
+			key:    "bytes",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewEncoder(tc.schema)
+			var got DuplicateBranchError
+			require.ErrorAs(t, err, &got)
+			require.Equal(t, tc.key, got.Key)
+		})
+	}
+}
+
 // TestRoundTrip_DecimalOverFixedRefReuse verifies that a decimal-over-fixed
 // registers its underlying fixed name, so a later Ref to that name resolves
 // to the same decimal plan rather than a raw fixed-bytes plan.

--- a/generic/roundtrip_test.go
+++ b/generic/roundtrip_test.go
@@ -20,12 +20,12 @@ func roundTrip(t *testing.T, s avro.Schema, v Value) Value {
 	enc, err := NewEncoder(s)
 	require.NoError(t, err)
 	var buf bytes.Buffer
-	require.NoError(t, avro.MarshalBinary(&buf, marshalAdapter{enc: enc, v: v}))
+	require.NoError(t, enc.Encode(&buf, v))
 
 	dec, err := NewDecoder(s)
 	require.NoError(t, err)
-	var out Value
-	require.NoError(t, avro.UnmarshalBinary(&buf, unmarshalAdapter{dec: dec, out: &out}))
+	out, err := dec.Decode(&buf)
+	require.NoError(t, err)
 	return out
 }
 

--- a/generic/roundtrip_test.go
+++ b/generic/roundtrip_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generic
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/z5labs/avro-go"
+)
+
+// roundTrip encodes v with s, then decodes and returns the decoded Value.
+func roundTrip(t *testing.T, s avro.Schema, v Value) Value {
+	t.Helper()
+	enc, err := NewEncoder(s)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, avro.MarshalBinary(&buf, marshalAdapter{enc: enc, v: v}))
+
+	dec, err := NewDecoder(s)
+	require.NoError(t, err)
+	var out Value
+	require.NoError(t, avro.UnmarshalBinary(&buf, unmarshalAdapter{dec: dec, out: &out}))
+	return out
+}
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		schema avro.Schema
+		value  Value
+	}{
+		{name: "null", schema: avro.Null{}, value: Null{}},
+		{name: "boolean", schema: avro.Boolean{}, value: Bool(true)},
+		{name: "int", schema: avro.Int{}, value: Int(-123456)},
+		{name: "long", schema: avro.Long{}, value: Long(1234567890123)},
+		{name: "float", schema: avro.Float{}, value: Float(3.14)},
+		{name: "double", schema: avro.Double{}, value: Double(2.718281828)},
+		{name: "bytes", schema: avro.Bytes{}, value: Bytes{0xde, 0xad, 0xbe, 0xef}},
+		{name: "string", schema: avro.String{}, value: String("hello, world")},
+		{
+			name: "record",
+			schema: avro.Record{
+				Name: "User",
+				Fields: []*avro.Field{
+					{Name: "id", Type: avro.Long{}},
+					{Name: "name", Type: avro.String{}},
+				},
+			},
+			value: Record{Fields: []Field{
+				{Name: "id", Value: Long(42)},
+				{Name: "name", Value: String("ada")},
+			}},
+		},
+		{
+			name:   "enum",
+			schema: avro.Enum{Name: "Color", Symbols: []string{"RED", "GREEN", "BLUE"}},
+			value:  Enum{Symbol: "GREEN"},
+		},
+		{
+			name:   "array",
+			schema: avro.Array{Items: avro.Long{}},
+			value:  Array{Long(1), Long(2), Long(3)},
+		},
+		{
+			name:   "empty array",
+			schema: avro.Array{Items: avro.Long{}},
+			value:  Array{},
+		},
+		{
+			name:   "map",
+			schema: avro.Map{Values: avro.Long{}},
+			value:  Map{"a": Long(1), "b": Long(2)},
+		},
+		{
+			name:   "empty map",
+			schema: avro.Map{Values: avro.Long{}},
+			value:  Map{},
+		},
+		{
+			name:   "union null",
+			schema: avro.Union{Types: []avro.Schema{avro.Null{}, avro.String{}}},
+			value:  Union{Index: 0, Value: Null{}},
+		},
+		{
+			name:   "union string",
+			schema: avro.Union{Types: []avro.Schema{avro.Null{}, avro.String{}}},
+			value:  Union{Index: 1, Value: String("hi")},
+		},
+		{
+			name:   "fixed",
+			schema: avro.Fixed{Name: "MD5", Size: 4},
+			value:  Fixed{0x01, 0x02, 0x03, 0x04},
+		},
+		// logical types
+		{
+			name:   "decimal over bytes positive",
+			schema: avro.Decimal{Precision: 9, Scale: 2, Underlying: avro.Bytes{}},
+			value:  Decimal{Unscaled: big.NewInt(12345)},
+		},
+		{
+			name:   "decimal over bytes negative",
+			schema: avro.Decimal{Precision: 9, Scale: 2, Underlying: avro.Bytes{}},
+			value:  Decimal{Unscaled: big.NewInt(-12345)},
+		},
+		{
+			name:   "decimal over fixed",
+			schema: avro.Decimal{Precision: 9, Scale: 2, Underlying: avro.Fixed{Name: "Dec", Size: 8}},
+			value:  Decimal{Unscaled: big.NewInt(-1)},
+		},
+		{
+			name:   "uuid",
+			schema: avro.UUID{},
+			value:  UUID("123e4567-e89b-12d3-a456-426614174000"),
+		},
+		{name: "date", schema: avro.Date{}, value: Date(19000)},
+		{name: "time-millis", schema: avro.TimeMillis{}, value: TimeMillis(123456)},
+		{name: "time-micros", schema: avro.TimeMicros{}, value: TimeMicros(123456789)},
+		{name: "timestamp-millis", schema: avro.TimestampMillis{}, value: TimestampMillis(1700000000000)},
+		{name: "timestamp-micros", schema: avro.TimestampMicros{}, value: TimestampMicros(1700000000000000)},
+		{name: "timestamp-nanos", schema: avro.TimestampNanos{}, value: TimestampNanos(1700000000000000000)},
+		{name: "local-timestamp-millis", schema: avro.LocalTimestampMillis{}, value: LocalTimestampMillis(1)},
+		{name: "local-timestamp-micros", schema: avro.LocalTimestampMicros{}, value: LocalTimestampMicros(1)},
+		{name: "local-timestamp-nanos", schema: avro.LocalTimestampNanos{}, value: LocalTimestampNanos(1)},
+		{
+			name:   "duration",
+			schema: avro.Duration{},
+			value:  Duration{Months: 12, Days: 31, Millis: 86399999},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := roundTrip(t, tc.schema, tc.value)
+			// Decimal needs special compare because *big.Int identity differs.
+			if d, ok := tc.value.(Decimal); ok {
+				gd, ok := got.(Decimal)
+				require.True(t, ok)
+				require.Equal(t, 0, d.Unscaled.Cmp(gd.Unscaled))
+				return
+			}
+			require.Equal(t, tc.value, got)
+		})
+	}
+}
+
+func TestRoundTrip_RecursiveRecord(t *testing.T) {
+	t.Parallel()
+
+	schema := avro.Record{
+		Name: "Node",
+		Fields: []*avro.Field{
+			{Name: "v", Type: avro.Long{}},
+			{Name: "next", Type: avro.Union{Types: []avro.Schema{avro.Null{}, avro.Ref{Name: "Node"}}}},
+		},
+	}
+	v := Record{Fields: []Field{
+		{Name: "v", Value: Long(1)},
+		{Name: "next", Value: Union{Index: 1, Value: Record{Fields: []Field{
+			{Name: "v", Value: Long(2)},
+			{Name: "next", Value: Union{Index: 0, Value: Null{}}},
+		}}}},
+	}}
+
+	got := roundTrip(t, schema, v)
+	require.Equal(t, v, got)
+}

--- a/generic/roundtrip_test.go
+++ b/generic/roundtrip_test.go
@@ -173,3 +173,68 @@ func TestRoundTrip_RecursiveRecord(t *testing.T) {
 	got := roundTrip(t, schema, v)
 	require.Equal(t, v, got)
 }
+
+// TestRoundTrip_RefInheritsEnclosingNamespace covers the Avro spec rule that
+// an unqualified Ref resolves against the enclosing record's namespace, even
+// when the schema is built programmatically (no JSON parsing to fill in
+// inherited Namespace fields).
+func TestRoundTrip_RefInheritsEnclosingNamespace(t *testing.T) {
+	t.Parallel()
+
+	schema := avro.Record{
+		Name:      "Node",
+		Namespace: "com.example",
+		Fields: []*avro.Field{
+			{Name: "v", Type: avro.Long{}},
+			// Ref carries no Namespace; it must inherit "com.example".
+			{Name: "next", Type: avro.Union{Types: []avro.Schema{avro.Null{}, avro.Ref{Name: "Node"}}}},
+		},
+	}
+	v := Record{Fields: []Field{
+		{Name: "v", Value: Long(7)},
+		{Name: "next", Value: Union{Index: 0, Value: Null{}}},
+	}}
+	got := roundTrip(t, schema, v)
+	require.Equal(t, v, got)
+}
+
+// TestRoundTrip_DecimalOverFixedRefReuse verifies that a decimal-over-fixed
+// registers its underlying fixed name, so a later Ref to that name resolves
+// to the same decimal plan rather than a raw fixed-bytes plan.
+func TestRoundTrip_DecimalOverFixedRefReuse(t *testing.T) {
+	t.Parallel()
+
+	dec := avro.Decimal{
+		Precision:  9,
+		Scale:      2,
+		Underlying: avro.Fixed{Name: "Money", Namespace: "com.example", Size: 8},
+	}
+	schema := avro.Record{
+		Name:      "Order",
+		Namespace: "com.example",
+		Fields: []*avro.Field{
+			{Name: "price", Type: dec},
+			{Name: "tax", Type: avro.Ref{Name: "Money"}},
+		},
+	}
+	v := Record{Fields: []Field{
+		{Name: "price", Value: Decimal{Unscaled: big.NewInt(12345)}},
+		{Name: "tax", Value: Decimal{Unscaled: big.NewInt(678)}},
+	}}
+
+	enc, err := NewEncoder(schema)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, enc.Encode(&buf, v))
+
+	d, err := NewDecoder(schema)
+	require.NoError(t, err)
+	out, err := d.Decode(&buf)
+	require.NoError(t, err)
+
+	rec := out.(Record)
+	gotPrice := rec.Fields[0].Value.(Decimal)
+	gotTax := rec.Fields[1].Value.(Decimal)
+	require.Equal(t, 0, big.NewInt(12345).Cmp(gotPrice.Unscaled))
+	require.Equal(t, 0, big.NewInt(678).Cmp(gotTax.Unscaled))
+}

--- a/schema.go
+++ b/schema.go
@@ -87,12 +87,11 @@ type Field struct {
 
 // Record is a named record schema.
 type Record struct {
-	Name       string
-	Namespace  string
-	Doc        string
-	Aliases    []string
-	Fields     []*Field
-	Properties map[string]any
+	Name      string
+	Namespace string
+	Doc       string
+	Aliases   []string
+	Fields    []*Field
 }
 
 func (Record) schema() {}

--- a/schema.go
+++ b/schema.go
@@ -220,9 +220,11 @@ type LocalTimestampNanos struct{}
 
 func (LocalTimestampNanos) schema() {}
 
-// Duration is the Avro "duration" logical type. It must be backed by a Fixed
-// schema whose Size is 12. The wire form is three little-endian unsigned
-// 32-bit integers: months, days, and milliseconds.
+// Duration is the Avro "duration" logical type. It is backed by a Fixed
+// schema whose Size is 12; Underlying.Size may be left as 0 (unspecified)
+// and is treated as 12 by MarshalJSON and the generic codec. Any other size
+// is rejected. The wire form is three little-endian unsigned 32-bit
+// integers: months, days, and milliseconds.
 type Duration struct {
 	Underlying Fixed
 }

--- a/schema.go
+++ b/schema.go
@@ -79,10 +79,13 @@ type Field struct {
 	Aliases []string
 	Doc     string
 	Type    Schema
-	// Default is the field's default value as defined by the Avro spec. A nil
-	// value means no default was specified.
-	Default any
-	Order   Order
+	// Default is the field's default value as defined by the Avro spec.
+	// HasDefault distinguishes "no default specified" (HasDefault=false) from
+	// an explicit null default (HasDefault=true, Default=nil), which is needed
+	// for unions whose first branch is null.
+	Default    any
+	HasDefault bool
+	Order      Order
 }
 
 // Record is a named record schema.

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avro
+
+// Schema represents an Avro schema. Concrete implementations model the JSON
+// schema spec at https://avro.apache.org/docs/1.12.0/specification/.
+//
+// Schema values are pure data; all validation is performed by the codecs that
+// consume them (e.g. github.com/z5labs/avro-go/generic.NewEncoder).
+type Schema interface {
+	schema()
+}
+
+// Null is the Avro "null" primitive schema.
+type Null struct{}
+
+func (Null) schema() {}
+
+// Boolean is the Avro "boolean" primitive schema.
+type Boolean struct{}
+
+func (Boolean) schema() {}
+
+// Int is the Avro "int" primitive schema (32-bit signed integer).
+type Int struct{}
+
+func (Int) schema() {}
+
+// Long is the Avro "long" primitive schema (64-bit signed integer).
+type Long struct{}
+
+func (Long) schema() {}
+
+// Float is the Avro "float" primitive schema (32-bit IEEE 754 float).
+type Float struct{}
+
+func (Float) schema() {}
+
+// Double is the Avro "double" primitive schema (64-bit IEEE 754 float).
+type Double struct{}
+
+func (Double) schema() {}
+
+// Bytes is the Avro "bytes" primitive schema (sequence of 8-bit bytes).
+type Bytes struct{}
+
+func (Bytes) schema() {}
+
+// String is the Avro "string" primitive schema (Unicode character sequence).
+type String struct{}
+
+func (String) schema() {}
+
+// Ref is a reference to a previously declared named schema (record, enum, or
+// fixed). It is distinct from the primitive schemas so that name resolution
+// is unambiguous.
+type Ref struct {
+	Name      string
+	Namespace string
+}
+
+func (Ref) schema() {}
+
+// Order describes the sort order of a record field.
+type Order int
+
+const (
+	OrderAscending Order = iota
+	OrderDescending
+	OrderIgnore
+)
+
+// Field describes a single field within a Record.
+type Field struct {
+	Name    string
+	Aliases []string
+	Doc     string
+	Type    Schema
+	// Default is the field's default value as defined by the Avro spec. A nil
+	// value means no default was specified.
+	Default any
+	Order   Order
+}
+
+// Record is a named record schema.
+type Record struct {
+	Name       string
+	Namespace  string
+	Doc        string
+	Aliases    []string
+	Fields     []*Field
+	Properties map[string]any
+}
+
+func (Record) schema() {}
+
+// Enum is a named enum schema.
+type Enum struct {
+	Name      string
+	Namespace string
+	Doc       string
+	Aliases   []string
+	Symbols   []string
+	// Default is the symbol used when a reader encounters an unknown writer
+	// symbol. An empty string means no default was specified.
+	Default string
+}
+
+func (Enum) schema() {}
+
+// Array is an array schema whose elements are of type Items.
+type Array struct {
+	Items Schema
+}
+
+func (Array) schema() {}
+
+// Map is a map schema whose values are of type Values. Keys are always strings.
+type Map struct {
+	Values Schema
+}
+
+func (Map) schema() {}
+
+// Union is a union schema. The order of Types matches the on-the-wire branch
+// index used by Avro's binary encoding.
+type Union struct {
+	Types []Schema
+}
+
+func (Union) schema() {}
+
+// Fixed is a named fixed-length byte sequence schema.
+type Fixed struct {
+	Name      string
+	Namespace string
+	Aliases   []string
+	Size      int
+}
+
+func (Fixed) schema() {}
+
+// Decimal is the Avro "decimal" logical type. It must be backed by either a
+// Bytes or Fixed schema. Precision is the maximum number of decimal digits;
+// Scale is the number of digits to the right of the decimal point and must
+// satisfy 0 <= Scale <= Precision.
+type Decimal struct {
+	Precision  int
+	Scale      int
+	Underlying Schema
+}
+
+func (Decimal) schema() {}
+
+// UUID is the Avro "uuid" logical type, backed by String.
+type UUID struct{}
+
+func (UUID) schema() {}
+
+// Date is the Avro "date" logical type, backed by Int. It represents days
+// since the Unix epoch (1970-01-01).
+type Date struct{}
+
+func (Date) schema() {}
+
+// TimeMillis is the Avro "time-millis" logical type, backed by Int.
+// Milliseconds after midnight, in the range [0, 86_400_000).
+type TimeMillis struct{}
+
+func (TimeMillis) schema() {}
+
+// TimeMicros is the Avro "time-micros" logical type, backed by Long.
+// Microseconds after midnight, in the range [0, 86_400_000_000).
+type TimeMicros struct{}
+
+func (TimeMicros) schema() {}
+
+// TimestampMillis is the Avro "timestamp-millis" logical type, backed by Long.
+// Milliseconds since the Unix epoch in UTC.
+type TimestampMillis struct{}
+
+func (TimestampMillis) schema() {}
+
+// TimestampMicros is the Avro "timestamp-micros" logical type, backed by Long.
+// Microseconds since the Unix epoch in UTC.
+type TimestampMicros struct{}
+
+func (TimestampMicros) schema() {}
+
+// TimestampNanos is the Avro "timestamp-nanos" logical type, backed by Long.
+// Nanoseconds since the Unix epoch in UTC.
+type TimestampNanos struct{}
+
+func (TimestampNanos) schema() {}
+
+// LocalTimestampMillis is the Avro "local-timestamp-millis" logical type, backed
+// by Long.
+type LocalTimestampMillis struct{}
+
+func (LocalTimestampMillis) schema() {}
+
+// LocalTimestampMicros is the Avro "local-timestamp-micros" logical type, backed
+// by Long.
+type LocalTimestampMicros struct{}
+
+func (LocalTimestampMicros) schema() {}
+
+// LocalTimestampNanos is the Avro "local-timestamp-nanos" logical type, backed
+// by Long.
+type LocalTimestampNanos struct{}
+
+func (LocalTimestampNanos) schema() {}
+
+// Duration is the Avro "duration" logical type, backed by Fixed of size 12.
+// The wire form is three little-endian unsigned 32-bit integers: months, days,
+// and milliseconds.
+type Duration struct{}
+
+func (Duration) schema() {}

--- a/schema.go
+++ b/schema.go
@@ -10,6 +10,10 @@ package avro
 //
 // Schema values are pure data; all validation is performed by the codecs that
 // consume them (e.g. github.com/z5labs/avro-go/generic.NewEncoder).
+//
+// Codecs in this module match concrete schema kinds by value type. Pointer
+// values (e.g. *Record) satisfy the Schema interface but are not accepted by
+// the codecs and will be rejected with an unsupported-schema error.
 type Schema interface {
 	schema()
 }
@@ -216,9 +220,11 @@ type LocalTimestampNanos struct{}
 
 func (LocalTimestampNanos) schema() {}
 
-// Duration is the Avro "duration" logical type, backed by Fixed of size 12.
-// The wire form is three little-endian unsigned 32-bit integers: months, days,
-// and milliseconds.
-type Duration struct{}
+// Duration is the Avro "duration" logical type. It must be backed by a Fixed
+// schema whose Size is 12. The wire form is three little-endian unsigned
+// 32-bit integers: months, days, and milliseconds.
+type Duration struct {
+	Underlying Fixed
+}
 
 func (Duration) schema() {}

--- a/schema_json.go
+++ b/schema_json.go
@@ -71,6 +71,22 @@ func (e InvalidDecimalUnderlyingError) Error() string {
 	return fmt.Sprintf("avro: decimal underlying must be bytes or fixed, got %T", e.Underlying)
 }
 
+// InvalidOrderError reports a Field with an Order outside the spec's
+// {ascending, descending, ignore} set.
+type InvalidOrderError struct{ Order Order }
+
+func (e InvalidOrderError) Error() string {
+	return fmt.Sprintf("avro: invalid field order %d", int(e.Order))
+}
+
+// InvalidOrderStringError reports a Field whose JSON "order" value is not
+// one of "ascending", "descending", or "ignore".
+type InvalidOrderStringError struct{ Value string }
+
+func (e InvalidOrderStringError) Error() string {
+	return fmt.Sprintf("avro: invalid field order %q", e.Value)
+}
+
 // ---- primitive marshalers ----
 
 func (Null) MarshalJSON() ([]byte, error)    { return []byte(`"null"`), nil }
@@ -100,12 +116,25 @@ func (r Record) MarshalJSON() ([]byte, error) {
 }
 
 func (f Field) MarshalJSON() ([]byte, error) {
+	var order string
+	switch f.Order {
+	case OrderAscending:
+		// spec default; omit
+	case OrderDescending:
+		order = "descending"
+	case OrderIgnore:
+		order = "ignore"
+	default:
+		return nil, InvalidOrderError{Order: f.Order}
+	}
 	return json.Marshal(struct {
 		Name    string   `json:"name"`
 		Doc     string   `json:"doc,omitempty"`
 		Aliases []string `json:"aliases,omitempty"`
 		Type    Schema   `json:"type"`
-	}{f.Name, f.Doc, f.Aliases, f.Type})
+		Default any      `json:"default,omitempty"`
+		Order   string   `json:"order,omitempty"`
+	}{f.Name, f.Doc, f.Aliases, f.Type, f.Default, order})
 }
 
 func (e Enum) MarshalJSON() ([]byte, error) {
@@ -398,11 +427,33 @@ func parseField(data []byte, namespace string) (*Field, error) {
 		return nil, err
 	}
 	f.Type = t
+	if rawDefault, ok := fobj["default"]; ok {
+		var v any
+		if err := json.Unmarshal(rawDefault, &v); err != nil {
+			return nil, err
+		}
+		f.Default = v
+	}
+	if rawOrder, ok := fobj["order"]; ok {
+		var s string
+		if err := json.Unmarshal(rawOrder, &s); err != nil {
+			return nil, err
+		}
+		switch s {
+		case "ascending":
+			f.Order = OrderAscending
+		case "descending":
+			f.Order = OrderDescending
+		case "ignore":
+			f.Order = OrderIgnore
+		default:
+			return nil, InvalidOrderStringError{Value: s}
+		}
+	}
 	return f, nil
 }
 
 func parseEnum(obj map[string]json.RawMessage, namespace string) (Enum, error) {
-	_ = namespace
 	e := Enum{}
 	if err := unmarshalIfPresent(obj, "name", &e.Name); err != nil {
 		return e, err
@@ -412,6 +463,9 @@ func parseEnum(obj map[string]json.RawMessage, namespace string) (Enum, error) {
 	}
 	if err := unmarshalIfPresent(obj, "namespace", &e.Namespace); err != nil {
 		return e, err
+	}
+	if e.Namespace == "" {
+		e.Namespace = namespace
 	}
 	if err := unmarshalIfPresent(obj, "doc", &e.Doc); err != nil {
 		return e, err
@@ -455,7 +509,7 @@ func parseMap(obj map[string]json.RawMessage, namespace string) (Map, error) {
 	return Map{Values: values}, nil
 }
 
-func parseFixed(obj map[string]json.RawMessage, _ string) (Fixed, error) {
+func parseFixed(obj map[string]json.RawMessage, namespace string) (Fixed, error) {
 	f := Fixed{}
 	if err := unmarshalIfPresent(obj, "name", &f.Name); err != nil {
 		return f, err
@@ -465,6 +519,9 @@ func parseFixed(obj map[string]json.RawMessage, _ string) (Fixed, error) {
 	}
 	if err := unmarshalIfPresent(obj, "namespace", &f.Namespace); err != nil {
 		return f, err
+	}
+	if f.Namespace == "" {
+		f.Namespace = namespace
 	}
 	if err := unmarshalIfPresent(obj, "aliases", &f.Aliases); err != nil {
 		return f, err
@@ -481,6 +538,9 @@ func parseFixed(obj map[string]json.RawMessage, _ string) (Fixed, error) {
 func parseLogical(under, lt string, obj map[string]json.RawMessage, namespace string) (Schema, error) {
 	switch lt {
 	case "decimal":
+		if _, ok := obj["precision"]; !ok {
+			return nil, MissingFieldError{Type: "decimal", Field: "precision"}
+		}
 		var precision, scale int
 		if err := unmarshalIfPresent(obj, "precision", &precision); err != nil {
 			return nil, err

--- a/schema_json.go
+++ b/schema_json.go
@@ -415,6 +415,12 @@ func parseRecord(obj map[string]json.RawMessage, namespace string) (Record, erro
 	if err := json.Unmarshal(rawFields, &rawList); err != nil {
 		return r, err
 	}
+	// json.Unmarshal accepts a JSON null into a slice (yielding nil). The Avro
+	// spec requires "fields" to be an array, so reject null explicitly rather
+	// than silently treating a malformed schema as an empty record.
+	if rawList == nil {
+		return r, MissingFieldError{Type: "record", Field: "fields"}
+	}
 	r.Fields = make([]*Field, len(rawList))
 	for i, raw := range rawList {
 		f, err := parseField(raw, ns)

--- a/schema_json.go
+++ b/schema_json.go
@@ -243,9 +243,22 @@ func (LocalTimestampNanos) MarshalJSON() ([]byte, error) {
 	return []byte(`{"type":"long","logicalType":"local-timestamp-nanos"}`), nil
 }
 
-func (Duration) MarshalJSON() ([]byte, error) {
-	// Avro requires fixed types to have a name; "duration" is conventional.
-	return []byte(`{"type":"fixed","name":"duration","size":12,"logicalType":"duration"}`), nil
+func (d Duration) MarshalJSON() ([]byte, error) {
+	// "duration" is the conventional name when none is supplied; the Underlying
+	// Fixed otherwise carries the user-chosen name/namespace/aliases so that
+	// JSON round-trips preserve identity.
+	name := d.Underlying.Name
+	if name == "" {
+		name = "duration"
+	}
+	return json.Marshal(struct {
+		Type        string   `json:"type"`
+		LogicalType string   `json:"logicalType"`
+		Name        string   `json:"name"`
+		Namespace   string   `json:"namespace,omitempty"`
+		Aliases     []string `json:"aliases,omitempty"`
+		Size        int      `json:"size"`
+	}{"fixed", "duration", name, d.Underlying.Namespace, d.Underlying.Aliases, 12})
 }
 
 // ---- parser ----
@@ -616,7 +629,7 @@ func parseLogical(under, lt string, obj map[string]json.RawMessage, namespace st
 		if !ok || fx.Size != 12 {
 			return underlying, nil
 		}
-		return Duration{}, nil
+		return Duration{Underlying: fx}, nil
 	default:
 		// Unknown logical type: per spec, ignore and use the underlying type.
 		return underlying, nil

--- a/schema_json.go
+++ b/schema_json.go
@@ -1,0 +1,545 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avro
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ParseJSON parses an Avro schema in its JSON definition form
+// (https://avro.apache.org/docs/1.12.0/specification/) into a Schema.
+//
+// All concrete Schema types in this package implement json.Marshaler so a
+// Schema can be written back to JSON via json.Marshal.
+func ParseJSON(data []byte) (Schema, error) {
+	return parseSchemaJSON(data, "")
+}
+
+// MissingFieldError reports a JSON object schema that lacks a required field
+// (e.g. a record schema with no "fields" entry).
+type MissingFieldError struct {
+	Type  string // schema kind: "record", "enum", "array", etc.
+	Field string // missing JSON field name
+}
+
+func (e MissingFieldError) Error() string {
+	return fmt.Sprintf("avro: %s schema: missing %q field", e.Type, e.Field)
+}
+
+// UnknownTypeError reports a JSON schema whose declared "type" is not a known
+// primitive, complex type, or named-type reference within scope.
+type UnknownTypeError struct{ Type string }
+
+func (e UnknownTypeError) Error() string {
+	return fmt.Sprintf("avro: unknown schema type %q", e.Type)
+}
+
+// UnknownLogicalTypeError reports a JSON schema with a "logicalType" the
+// parser does not recognize.
+type UnknownLogicalTypeError struct {
+	Underlying  string
+	LogicalType string
+}
+
+func (e UnknownLogicalTypeError) Error() string {
+	return fmt.Sprintf("avro: unknown logicalType %q on %q", e.LogicalType, e.Underlying)
+}
+
+// ErrEmptyJSON is returned when ParseJSON is given empty input.
+var ErrEmptyJSON = errors.New("avro: empty JSON")
+
+// UnexpectedTokenError reports a JSON document that starts with a token
+// other than '"', '[', or '{'.
+type UnexpectedTokenError struct{ Token byte }
+
+func (e UnexpectedTokenError) Error() string {
+	return fmt.Sprintf("avro: unexpected JSON token %q", e.Token)
+}
+
+// InvalidDecimalUnderlyingError reports a Decimal whose Underlying schema is
+// not Bytes or Fixed when marshaling to JSON.
+type InvalidDecimalUnderlyingError struct{ Underlying Schema }
+
+func (e InvalidDecimalUnderlyingError) Error() string {
+	return fmt.Sprintf("avro: decimal underlying must be bytes or fixed, got %T", e.Underlying)
+}
+
+// ---- primitive marshalers ----
+
+func (Null) MarshalJSON() ([]byte, error)    { return []byte(`"null"`), nil }
+func (Boolean) MarshalJSON() ([]byte, error) { return []byte(`"boolean"`), nil }
+func (Int) MarshalJSON() ([]byte, error)     { return []byte(`"int"`), nil }
+func (Long) MarshalJSON() ([]byte, error)    { return []byte(`"long"`), nil }
+func (Float) MarshalJSON() ([]byte, error)   { return []byte(`"float"`), nil }
+func (Double) MarshalJSON() ([]byte, error)  { return []byte(`"double"`), nil }
+func (Bytes) MarshalJSON() ([]byte, error)   { return []byte(`"bytes"`), nil }
+func (String) MarshalJSON() ([]byte, error)  { return []byte(`"string"`), nil }
+
+func (r Ref) MarshalJSON() ([]byte, error) {
+	return json.Marshal(qualifiedName(r.Namespace, r.Name))
+}
+
+// ---- composite marshalers ----
+
+func (r Record) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type      string   `json:"type"`
+		Name      string   `json:"name"`
+		Namespace string   `json:"namespace,omitempty"`
+		Doc       string   `json:"doc,omitempty"`
+		Aliases   []string `json:"aliases,omitempty"`
+		Fields    []*Field `json:"fields"`
+	}{"record", r.Name, r.Namespace, r.Doc, r.Aliases, r.Fields})
+}
+
+func (f Field) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Name    string   `json:"name"`
+		Doc     string   `json:"doc,omitempty"`
+		Aliases []string `json:"aliases,omitempty"`
+		Type    Schema   `json:"type"`
+	}{f.Name, f.Doc, f.Aliases, f.Type})
+}
+
+func (e Enum) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type      string   `json:"type"`
+		Name      string   `json:"name"`
+		Namespace string   `json:"namespace,omitempty"`
+		Doc       string   `json:"doc,omitempty"`
+		Aliases   []string `json:"aliases,omitempty"`
+		Symbols   []string `json:"symbols"`
+		Default   string   `json:"default,omitempty"`
+	}{"enum", e.Name, e.Namespace, e.Doc, e.Aliases, e.Symbols, e.Default})
+}
+
+func (a Array) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  string `json:"type"`
+		Items Schema `json:"items"`
+	}{"array", a.Items})
+}
+
+func (m Map) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type   string `json:"type"`
+		Values Schema `json:"values"`
+	}{"map", m.Values})
+}
+
+func (u Union) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.Types)
+}
+
+func (f Fixed) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type      string   `json:"type"`
+		Name      string   `json:"name"`
+		Namespace string   `json:"namespace,omitempty"`
+		Aliases   []string `json:"aliases,omitempty"`
+		Size      int      `json:"size"`
+	}{"fixed", f.Name, f.Namespace, f.Aliases, f.Size})
+}
+
+// ---- logical-type marshalers ----
+
+func (d Decimal) MarshalJSON() ([]byte, error) {
+	switch under := d.Underlying.(type) {
+	case Bytes:
+		return json.Marshal(struct {
+			Type        string `json:"type"`
+			LogicalType string `json:"logicalType"`
+			Precision   int    `json:"precision"`
+			Scale       int    `json:"scale,omitempty"`
+		}{"bytes", "decimal", d.Precision, d.Scale})
+	case Fixed:
+		return json.Marshal(struct {
+			Type        string   `json:"type"`
+			LogicalType string   `json:"logicalType"`
+			Name        string   `json:"name"`
+			Namespace   string   `json:"namespace,omitempty"`
+			Aliases     []string `json:"aliases,omitempty"`
+			Size        int      `json:"size"`
+			Precision   int      `json:"precision"`
+			Scale       int      `json:"scale,omitempty"`
+		}{"fixed", "decimal", under.Name, under.Namespace, under.Aliases, under.Size, d.Precision, d.Scale})
+	default:
+		return nil, InvalidDecimalUnderlyingError{Underlying: d.Underlying}
+	}
+}
+
+func (UUID) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"string","logicalType":"uuid"}`), nil
+}
+
+func (Date) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"int","logicalType":"date"}`), nil
+}
+
+func (TimeMillis) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"int","logicalType":"time-millis"}`), nil
+}
+
+func (TimeMicros) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"long","logicalType":"time-micros"}`), nil
+}
+
+func (TimestampMillis) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"long","logicalType":"timestamp-millis"}`), nil
+}
+
+func (TimestampMicros) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"long","logicalType":"timestamp-micros"}`), nil
+}
+
+func (TimestampNanos) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"long","logicalType":"timestamp-nanos"}`), nil
+}
+
+func (LocalTimestampMillis) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"long","logicalType":"local-timestamp-millis"}`), nil
+}
+
+func (LocalTimestampMicros) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"long","logicalType":"local-timestamp-micros"}`), nil
+}
+
+func (LocalTimestampNanos) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"long","logicalType":"local-timestamp-nanos"}`), nil
+}
+
+func (Duration) MarshalJSON() ([]byte, error) {
+	// Avro requires fixed types to have a name; "duration" is conventional.
+	return []byte(`{"type":"fixed","name":"duration","size":12,"logicalType":"duration"}`), nil
+}
+
+// ---- parser ----
+
+func parseSchemaJSON(data []byte, namespace string) (Schema, error) {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil, ErrEmptyJSON
+	}
+	switch data[0] {
+	case '"':
+		var name string
+		if err := json.Unmarshal(data, &name); err != nil {
+			return nil, err
+		}
+		return parseTypeName(name, namespace), nil
+	case '[':
+		var raw []json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return nil, err
+		}
+		types := make([]Schema, len(raw))
+		for i, r := range raw {
+			t, err := parseSchemaJSON(r, namespace)
+			if err != nil {
+				return nil, err
+			}
+			types[i] = t
+		}
+		return Union{Types: types}, nil
+	case '{':
+		return parseObjectJSON(data, namespace)
+	default:
+		return nil, UnexpectedTokenError{Token: data[0]}
+	}
+}
+
+func parseTypeName(name, namespace string) Schema {
+	switch name {
+	case "null":
+		return Null{}
+	case "boolean":
+		return Boolean{}
+	case "int":
+		return Int{}
+	case "long":
+		return Long{}
+	case "float":
+		return Float{}
+	case "double":
+		return Double{}
+	case "bytes":
+		return Bytes{}
+	case "string":
+		return String{}
+	}
+	// Otherwise it's a named-type reference. If the name is qualified, split it;
+	// otherwise inherit the enclosing namespace.
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		return Ref{Namespace: name[:i], Name: name[i+1:]}
+	}
+	return Ref{Name: name, Namespace: namespace}
+}
+
+func parseObjectJSON(data []byte, namespace string) (Schema, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+
+	typeRaw, ok := obj["type"]
+	if !ok {
+		return nil, MissingFieldError{Type: "object", Field: "type"}
+	}
+	var typeName string
+	if err := json.Unmarshal(typeRaw, &typeName); err != nil {
+		// "type" is itself a nested schema object/array.
+		return parseSchemaJSON(typeRaw, namespace)
+	}
+
+	// Logical-type schemas dispatch on the logicalType field.
+	if ltRaw, hasLogical := obj["logicalType"]; hasLogical {
+		var lt string
+		if err := json.Unmarshal(ltRaw, &lt); err != nil {
+			return nil, err
+		}
+		return parseLogical(typeName, lt, obj, namespace)
+	}
+
+	switch typeName {
+	case "null", "boolean", "int", "long", "float", "double", "bytes", "string":
+		return parseTypeName(typeName, namespace), nil
+	case "record":
+		return parseRecord(obj, namespace)
+	case "enum":
+		return parseEnum(obj, namespace)
+	case "array":
+		return parseArray(obj, namespace)
+	case "map":
+		return parseMap(obj, namespace)
+	case "fixed":
+		return parseFixed(obj, namespace)
+	default:
+		// Could be a named-type reference (rarely written in object form).
+		ref := parseTypeName(typeName, namespace)
+		if _, isRef := ref.(Ref); isRef {
+			return ref, nil
+		}
+		return nil, UnknownTypeError{Type: typeName}
+	}
+}
+
+func parseRecord(obj map[string]json.RawMessage, namespace string) (Record, error) {
+	r := Record{}
+	if err := unmarshalIfPresent(obj, "name", &r.Name); err != nil {
+		return r, err
+	}
+	if r.Name == "" {
+		return r, MissingFieldError{Type: "record", Field: "name"}
+	}
+	if err := unmarshalIfPresent(obj, "namespace", &r.Namespace); err != nil {
+		return r, err
+	}
+	if err := unmarshalIfPresent(obj, "doc", &r.Doc); err != nil {
+		return r, err
+	}
+	if err := unmarshalIfPresent(obj, "aliases", &r.Aliases); err != nil {
+		return r, err
+	}
+	ns := r.Namespace
+	if ns == "" {
+		ns = namespace
+	}
+
+	rawFields, ok := obj["fields"]
+	if !ok {
+		return r, MissingFieldError{Type: "record", Field: "fields"}
+	}
+	var rawList []json.RawMessage
+	if err := json.Unmarshal(rawFields, &rawList); err != nil {
+		return r, err
+	}
+	r.Fields = make([]*Field, len(rawList))
+	for i, raw := range rawList {
+		f, err := parseField(raw, ns)
+		if err != nil {
+			return r, err
+		}
+		r.Fields[i] = f
+	}
+	return r, nil
+}
+
+func parseField(data []byte, namespace string) (*Field, error) {
+	var fobj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fobj); err != nil {
+		return nil, err
+	}
+	f := &Field{}
+	if err := unmarshalIfPresent(fobj, "name", &f.Name); err != nil {
+		return nil, err
+	}
+	if f.Name == "" {
+		return nil, MissingFieldError{Type: "field", Field: "name"}
+	}
+	if err := unmarshalIfPresent(fobj, "doc", &f.Doc); err != nil {
+		return nil, err
+	}
+	if err := unmarshalIfPresent(fobj, "aliases", &f.Aliases); err != nil {
+		return nil, err
+	}
+	rawType, ok := fobj["type"]
+	if !ok {
+		return nil, MissingFieldError{Type: "field", Field: "type"}
+	}
+	t, err := parseSchemaJSON(rawType, namespace)
+	if err != nil {
+		return nil, err
+	}
+	f.Type = t
+	return f, nil
+}
+
+func parseEnum(obj map[string]json.RawMessage, namespace string) (Enum, error) {
+	_ = namespace
+	e := Enum{}
+	if err := unmarshalIfPresent(obj, "name", &e.Name); err != nil {
+		return e, err
+	}
+	if e.Name == "" {
+		return e, MissingFieldError{Type: "enum", Field: "name"}
+	}
+	if err := unmarshalIfPresent(obj, "namespace", &e.Namespace); err != nil {
+		return e, err
+	}
+	if err := unmarshalIfPresent(obj, "doc", &e.Doc); err != nil {
+		return e, err
+	}
+	if err := unmarshalIfPresent(obj, "aliases", &e.Aliases); err != nil {
+		return e, err
+	}
+	if err := unmarshalIfPresent(obj, "symbols", &e.Symbols); err != nil {
+		return e, err
+	}
+	if e.Symbols == nil {
+		return e, MissingFieldError{Type: "enum", Field: "symbols"}
+	}
+	if err := unmarshalIfPresent(obj, "default", &e.Default); err != nil {
+		return e, err
+	}
+	return e, nil
+}
+
+func parseArray(obj map[string]json.RawMessage, namespace string) (Array, error) {
+	rawItems, ok := obj["items"]
+	if !ok {
+		return Array{}, MissingFieldError{Type: "array", Field: "items"}
+	}
+	items, err := parseSchemaJSON(rawItems, namespace)
+	if err != nil {
+		return Array{}, err
+	}
+	return Array{Items: items}, nil
+}
+
+func parseMap(obj map[string]json.RawMessage, namespace string) (Map, error) {
+	rawValues, ok := obj["values"]
+	if !ok {
+		return Map{}, MissingFieldError{Type: "map", Field: "values"}
+	}
+	values, err := parseSchemaJSON(rawValues, namespace)
+	if err != nil {
+		return Map{}, err
+	}
+	return Map{Values: values}, nil
+}
+
+func parseFixed(obj map[string]json.RawMessage, _ string) (Fixed, error) {
+	f := Fixed{}
+	if err := unmarshalIfPresent(obj, "name", &f.Name); err != nil {
+		return f, err
+	}
+	if f.Name == "" {
+		return f, MissingFieldError{Type: "fixed", Field: "name"}
+	}
+	if err := unmarshalIfPresent(obj, "namespace", &f.Namespace); err != nil {
+		return f, err
+	}
+	if err := unmarshalIfPresent(obj, "aliases", &f.Aliases); err != nil {
+		return f, err
+	}
+	if _, ok := obj["size"]; !ok {
+		return f, MissingFieldError{Type: "fixed", Field: "size"}
+	}
+	if err := unmarshalIfPresent(obj, "size", &f.Size); err != nil {
+		return f, err
+	}
+	return f, nil
+}
+
+func parseLogical(under, lt string, obj map[string]json.RawMessage, namespace string) (Schema, error) {
+	switch lt {
+	case "decimal":
+		var precision, scale int
+		if err := unmarshalIfPresent(obj, "precision", &precision); err != nil {
+			return nil, err
+		}
+		if err := unmarshalIfPresent(obj, "scale", &scale); err != nil {
+			return nil, err
+		}
+		switch under {
+		case "bytes":
+			return Decimal{Precision: precision, Scale: scale, Underlying: Bytes{}}, nil
+		case "fixed":
+			fx, err := parseFixed(obj, namespace)
+			if err != nil {
+				return nil, err
+			}
+			return Decimal{Precision: precision, Scale: scale, Underlying: fx}, nil
+		default:
+			return nil, UnknownLogicalTypeError{Underlying: under, LogicalType: lt}
+		}
+	case "uuid":
+		return UUID{}, nil
+	case "date":
+		return Date{}, nil
+	case "time-millis":
+		return TimeMillis{}, nil
+	case "time-micros":
+		return TimeMicros{}, nil
+	case "timestamp-millis":
+		return TimestampMillis{}, nil
+	case "timestamp-micros":
+		return TimestampMicros{}, nil
+	case "timestamp-nanos":
+		return TimestampNanos{}, nil
+	case "local-timestamp-millis":
+		return LocalTimestampMillis{}, nil
+	case "local-timestamp-micros":
+		return LocalTimestampMicros{}, nil
+	case "local-timestamp-nanos":
+		return LocalTimestampNanos{}, nil
+	case "duration":
+		return Duration{}, nil
+	default:
+		return nil, UnknownLogicalTypeError{Underlying: under, LogicalType: lt}
+	}
+}
+
+// ---- helpers ----
+
+func unmarshalIfPresent(obj map[string]json.RawMessage, key string, dst any) error {
+	raw, ok := obj[key]
+	if !ok {
+		return nil
+	}
+	return json.Unmarshal(raw, dst)
+}
+
+func qualifiedName(namespace, name string) string {
+	if name == "" || strings.Contains(name, ".") || namespace == "" {
+		return name
+	}
+	return namespace + "." + name
+}

--- a/schema_json.go
+++ b/schema_json.go
@@ -60,6 +60,14 @@ func (e InvalidDecimalUnderlyingError) Error() string {
 	return fmt.Sprintf("avro: decimal underlying must be bytes or fixed, got %T", e.Underlying)
 }
 
+// InvalidDurationSizeError reports a Duration whose Underlying.Size is set
+// to a value other than 12 (the size required by the Avro spec).
+type InvalidDurationSizeError struct{ Size int }
+
+func (e InvalidDurationSizeError) Error() string {
+	return fmt.Sprintf("avro: duration underlying size must be 12, got %d", e.Size)
+}
+
 // InvalidOrderError reports a Field with an Order outside the spec's
 // {ascending, descending, ignore} set.
 type InvalidOrderError struct{ Order Order }
@@ -244,6 +252,12 @@ func (LocalTimestampNanos) MarshalJSON() ([]byte, error) {
 }
 
 func (d Duration) MarshalJSON() ([]byte, error) {
+	// The Avro spec fixes a duration's underlying fixed size at 12 bytes. Size
+	// 0 means the caller did not specify a size (we then emit the canonical
+	// 12); any other value would silently misrepresent the in-memory schema.
+	if d.Underlying.Size != 0 && d.Underlying.Size != 12 {
+		return nil, InvalidDurationSizeError{Size: d.Underlying.Size}
+	}
 	// "duration" is the conventional name when none is supplied; the Underlying
 	// Fixed otherwise carries the user-chosen name/namespace/aliases so that
 	// JSON round-trips preserve identity.

--- a/schema_json.go
+++ b/schema_json.go
@@ -116,14 +116,24 @@ func (f Field) MarshalJSON() ([]byte, error) {
 	default:
 		return nil, InvalidOrderError{Order: f.Order}
 	}
+	// json.RawMessage with omitempty lets us distinguish "no default" (nil
+	// slice, omitted) from an explicit null default (the bytes "null", emitted).
+	var def json.RawMessage
+	if f.HasDefault {
+		b, err := json.Marshal(f.Default)
+		if err != nil {
+			return nil, err
+		}
+		def = b
+	}
 	return json.Marshal(struct {
-		Name    string   `json:"name"`
-		Doc     string   `json:"doc,omitempty"`
-		Aliases []string `json:"aliases,omitempty"`
-		Type    Schema   `json:"type"`
-		Default any      `json:"default,omitempty"`
-		Order   string   `json:"order,omitempty"`
-	}{f.Name, f.Doc, f.Aliases, f.Type, f.Default, order})
+		Name    string          `json:"name"`
+		Doc     string          `json:"doc,omitempty"`
+		Aliases []string        `json:"aliases,omitempty"`
+		Type    Schema          `json:"type"`
+		Default json.RawMessage `json:"default,omitempty"`
+		Order   string          `json:"order,omitempty"`
+	}{f.Name, f.Doc, f.Aliases, f.Type, def, order})
 }
 
 func (e Enum) MarshalJSON() ([]byte, error) {
@@ -417,6 +427,7 @@ func parseField(data []byte, namespace string) (*Field, error) {
 	}
 	f.Type = t
 	if rawDefault, ok := fobj["default"]; ok {
+		f.HasDefault = true
 		var v any
 		if err := json.Unmarshal(rawDefault, &v); err != nil {
 			return nil, err
@@ -613,15 +624,30 @@ func parseLogical(under, lt string, obj map[string]json.RawMessage, namespace st
 }
 
 // parseLogicalUnderlying resolves the "type" field of a logical-type schema
-// into its base Schema. Avro logical types are layered only on primitives or
-// fixed; any other value of under is rejected.
+// into its base Schema. Per the Avro spec's fallback rule, the underlying
+// schema must be parseable for any valid Avro type so that an invalid or
+// unknown logical type can be ignored cleanly.
 func parseLogicalUnderlying(under string, obj map[string]json.RawMessage, namespace string) (Schema, error) {
 	switch under {
 	case "null", "boolean", "int", "long", "float", "double", "bytes", "string":
 		return parseTypeName(under, namespace), nil
+	case "record":
+		return parseRecord(obj, namespace)
+	case "enum":
+		return parseEnum(obj, namespace)
+	case "array":
+		return parseArray(obj, namespace)
+	case "map":
+		return parseMap(obj, namespace)
 	case "fixed":
 		return parseFixed(obj, namespace)
 	default:
+		// Treat unrecognized type names as named-type references (matches
+		// parseObjectJSON's fallback for non-keyword types).
+		ref := parseTypeName(under, namespace)
+		if _, isRef := ref.(Ref); isRef {
+			return ref, nil
+		}
 		return nil, UnknownTypeError{Type: under}
 	}
 }

--- a/schema_json.go
+++ b/schema_json.go
@@ -41,17 +41,6 @@ func (e UnknownTypeError) Error() string {
 	return fmt.Sprintf("avro: unknown schema type %q", e.Type)
 }
 
-// UnknownLogicalTypeError reports a JSON schema with a "logicalType" the
-// parser does not recognize.
-type UnknownLogicalTypeError struct {
-	Underlying  string
-	LogicalType string
-}
-
-func (e UnknownLogicalTypeError) Error() string {
-	return fmt.Sprintf("avro: unknown logicalType %q on %q", e.LogicalType, e.Underlying)
-}
-
 // ErrEmptyJSON is returned when ParseJSON is given empty input.
 var ErrEmptyJSON = errors.New("avro: empty JSON")
 
@@ -535,9 +524,21 @@ func parseFixed(obj map[string]json.RawMessage, namespace string) (Fixed, error)
 	return f, nil
 }
 
+// parseLogical decodes an Avro JSON object whose declared "logicalType" field
+// is non-empty. Per the Avro spec, when the underlying type does not match the
+// logical type's required base (or the logical type is unknown), the logical
+// type is ignored and the underlying type is returned as the schema.
 func parseLogical(under, lt string, obj map[string]json.RawMessage, namespace string) (Schema, error) {
+	underlying, err := parseLogicalUnderlying(under, obj, namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	switch lt {
 	case "decimal":
+		if under != "bytes" && under != "fixed" {
+			return underlying, nil
+		}
 		if _, ok := obj["precision"]; !ok {
 			return nil, MissingFieldError{Type: "decimal", Field: "precision"}
 		}
@@ -548,42 +549,80 @@ func parseLogical(under, lt string, obj map[string]json.RawMessage, namespace st
 		if err := unmarshalIfPresent(obj, "scale", &scale); err != nil {
 			return nil, err
 		}
-		switch under {
-		case "bytes":
-			return Decimal{Precision: precision, Scale: scale, Underlying: Bytes{}}, nil
-		case "fixed":
-			fx, err := parseFixed(obj, namespace)
-			if err != nil {
-				return nil, err
-			}
-			return Decimal{Precision: precision, Scale: scale, Underlying: fx}, nil
-		default:
-			return nil, UnknownLogicalTypeError{Underlying: under, LogicalType: lt}
-		}
+		return Decimal{Precision: precision, Scale: scale, Underlying: underlying}, nil
 	case "uuid":
+		if under != "string" {
+			return underlying, nil
+		}
 		return UUID{}, nil
 	case "date":
+		if under != "int" {
+			return underlying, nil
+		}
 		return Date{}, nil
 	case "time-millis":
+		if under != "int" {
+			return underlying, nil
+		}
 		return TimeMillis{}, nil
 	case "time-micros":
+		if under != "long" {
+			return underlying, nil
+		}
 		return TimeMicros{}, nil
 	case "timestamp-millis":
+		if under != "long" {
+			return underlying, nil
+		}
 		return TimestampMillis{}, nil
 	case "timestamp-micros":
+		if under != "long" {
+			return underlying, nil
+		}
 		return TimestampMicros{}, nil
 	case "timestamp-nanos":
+		if under != "long" {
+			return underlying, nil
+		}
 		return TimestampNanos{}, nil
 	case "local-timestamp-millis":
+		if under != "long" {
+			return underlying, nil
+		}
 		return LocalTimestampMillis{}, nil
 	case "local-timestamp-micros":
+		if under != "long" {
+			return underlying, nil
+		}
 		return LocalTimestampMicros{}, nil
 	case "local-timestamp-nanos":
+		if under != "long" {
+			return underlying, nil
+		}
 		return LocalTimestampNanos{}, nil
 	case "duration":
+		fx, ok := underlying.(Fixed)
+		if !ok || fx.Size != 12 {
+			return underlying, nil
+		}
 		return Duration{}, nil
 	default:
-		return nil, UnknownLogicalTypeError{Underlying: under, LogicalType: lt}
+		// Unknown logical type: per spec, ignore and use the underlying type.
+		return underlying, nil
+	}
+}
+
+// parseLogicalUnderlying resolves the "type" field of a logical-type schema
+// into its base Schema. Avro logical types are layered only on primitives or
+// fixed; any other value of under is rejected.
+func parseLogicalUnderlying(under string, obj map[string]json.RawMessage, namespace string) (Schema, error) {
+	switch under {
+	case "null", "boolean", "int", "long", "float", "double", "bytes", "string":
+		return parseTypeName(under, namespace), nil
+	case "fixed":
+		return parseFixed(obj, namespace)
+	default:
+		return nil, UnknownTypeError{Type: under}
 	}
 }
 

--- a/schema_json_test.go
+++ b/schema_json_test.go
@@ -376,11 +376,15 @@ func TestField_DefaultAndOrderRoundTrip(t *testing.T) {
 	}{
 		{
 			name:  "default string",
-			field: &Field{Name: "x", Type: String{}, Default: "hello"},
+			field: &Field{Name: "x", Type: String{}, Default: "hello", HasDefault: true},
 		},
 		{
-			name:  "default null",
-			field: &Field{Name: "x", Type: Union{Types: []Schema{Null{}, String{}}}, Default: nil},
+			name:  "no default specified",
+			field: &Field{Name: "x", Type: Union{Types: []Schema{Null{}, String{}}}},
+		},
+		{
+			name:  "explicit null default for union",
+			field: &Field{Name: "x", Type: Union{Types: []Schema{Null{}, String{}}}, Default: nil, HasDefault: true},
 		},
 		{
 			name:  "order descending",
@@ -388,7 +392,7 @@ func TestField_DefaultAndOrderRoundTrip(t *testing.T) {
 		},
 		{
 			name:  "order ignore with default",
-			field: &Field{Name: "x", Type: Boolean{}, Default: true, Order: OrderIgnore},
+			field: &Field{Name: "x", Type: Boolean{}, Default: true, HasDefault: true, Order: OrderIgnore},
 		},
 	}
 
@@ -404,7 +408,51 @@ func TestField_DefaultAndOrderRoundTrip(t *testing.T) {
 			rec := got.(Record)
 			require.Equal(t, tc.field.Name, rec.Fields[0].Name)
 			require.Equal(t, tc.field.Order, rec.Fields[0].Order)
+			require.Equal(t, tc.field.HasDefault, rec.Fields[0].HasDefault)
 			require.Equal(t, tc.field.Default, rec.Fields[0].Default)
 		})
 	}
+}
+
+// TestField_ExplicitNullDefaultEmitted verifies the JSON wire form for an
+// explicit null default — the "default" key must be present with a null value,
+// which is the only way to give a union-with-null branch a default in Avro.
+func TestField_ExplicitNullDefaultEmitted(t *testing.T) {
+	t.Parallel()
+
+	f := &Field{
+		Name:       "x",
+		Type:       Union{Types: []Schema{Null{}, String{}}},
+		Default:    nil,
+		HasDefault: true,
+	}
+	schema := Record{Name: "R", Fields: []*Field{f}}
+	data, err := json.Marshal(schema)
+	require.NoError(t, err)
+	require.JSONEq(t,
+		`{"type":"record","name":"R","fields":[{"name":"x","type":["null","string"],"default":null}]}`,
+		string(data),
+	)
+}
+
+// TestParseJSON_ComplexUnderlyingFallback covers the Avro spec rule that an
+// invalid logicalType is ignored, including when the underlying type is a
+// complex (non-primitive, non-fixed) Avro type.
+func TestParseJSON_ComplexUnderlyingFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("record with bogus logicalType falls back to record", func(t *testing.T) {
+		t.Parallel()
+		got, err := ParseJSON([]byte(`{"type":"record","name":"R","logicalType":"bogus","fields":[{"name":"a","type":"int"}]}`))
+		require.NoError(t, err)
+		want := Record{Name: "R", Fields: []*Field{{Name: "a", Type: Int{}}}}
+		require.Equal(t, want, got)
+	})
+
+	t.Run("array with bogus logicalType falls back to array", func(t *testing.T) {
+		t.Parallel()
+		got, err := ParseJSON([]byte(`{"type":"array","items":"long","logicalType":"bogus"}`))
+		require.NoError(t, err)
+		require.Equal(t, Array{Items: Long{}}, got)
+	})
 }

--- a/schema_json_test.go
+++ b/schema_json_test.go
@@ -259,12 +259,13 @@ func TestParseJSON_Errors(t *testing.T) {
 		require.Equal(t, "fields", got.Field)
 	})
 
-	t.Run("unknown logical type", func(t *testing.T) {
+	t.Run("unknown logical type falls back to underlying", func(t *testing.T) {
 		t.Parallel()
-		_, err := ParseJSON([]byte(`{"type":"int","logicalType":"bogus"}`))
-		var got UnknownLogicalTypeError
-		require.ErrorAs(t, err, &got)
-		require.Equal(t, "bogus", got.LogicalType)
+		// Per Avro spec, an unrecognized logicalType is ignored and the
+		// underlying Avro type is used.
+		got, err := ParseJSON([]byte(`{"type":"int","logicalType":"bogus"}`))
+		require.NoError(t, err)
+		require.Equal(t, Int{}, got)
 	})
 
 	t.Run("missing fixed size", func(t *testing.T) {
@@ -291,6 +292,54 @@ func TestParseJSON_Errors(t *testing.T) {
 		require.ErrorAs(t, err, &got)
 		require.Equal(t, "sideways", got.Value)
 	})
+}
+
+// TestParseJSON_LogicalTypeFallback covers the Avro spec rule that a logical
+// type whose underlying does not match the spec's required base must be
+// ignored, leaving the underlying schema as the result.
+func TestParseJSON_LogicalTypeFallback(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		json string
+		want Schema
+	}{
+		{
+			name: "uuid on int falls back to int",
+			json: `{"type":"int","logicalType":"uuid"}`,
+			want: Int{},
+		},
+		{
+			name: "date on long falls back to long",
+			json: `{"type":"long","logicalType":"date"}`,
+			want: Long{},
+		},
+		{
+			name: "timestamp-millis on int falls back to int",
+			json: `{"type":"int","logicalType":"timestamp-millis"}`,
+			want: Int{},
+		},
+		{
+			name: "decimal on string falls back to string",
+			json: `{"type":"string","logicalType":"decimal","precision":4}`,
+			want: String{},
+		},
+		{
+			name: "duration on fixed wrong size falls back to fixed",
+			json: `{"type":"fixed","name":"D","size":8,"logicalType":"duration"}`,
+			want: Fixed{Name: "D", Size: 8},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseJSON([]byte(tc.json))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // TestParseJSON_NamespaceInheritance verifies that nested named types without

--- a/schema_json_test.go
+++ b/schema_json_test.go
@@ -274,4 +274,88 @@ func TestParseJSON_Errors(t *testing.T) {
 		require.ErrorAs(t, err, &got)
 		require.Equal(t, "size", got.Field)
 	})
+
+	t.Run("missing decimal precision", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseJSON([]byte(`{"type":"bytes","logicalType":"decimal","scale":2}`))
+		var got MissingFieldError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "decimal", got.Type)
+		require.Equal(t, "precision", got.Field)
+	})
+
+	t.Run("invalid order string", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseJSON([]byte(`{"type":"record","name":"R","fields":[{"name":"a","type":"int","order":"sideways"}]}`))
+		var got InvalidOrderStringError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "sideways", got.Value)
+	})
+}
+
+// TestParseJSON_NamespaceInheritance verifies that nested named types without
+// an explicit "namespace" inherit the enclosing record's namespace, so Refs
+// resolve consistently regardless of where the type is defined.
+func TestParseJSON_NamespaceInheritance(t *testing.T) {
+	t.Parallel()
+
+	src := `{
+        "type": "record",
+        "name": "Outer",
+        "namespace": "com.example",
+        "fields": [
+            {"name": "color", "type": {"type": "enum", "name": "Color", "symbols": ["RED"]}},
+            {"name": "hash",  "type": {"type": "fixed", "name": "MD5", "size": 16}}
+        ]
+    }`
+	got, err := ParseJSON([]byte(src))
+	require.NoError(t, err)
+
+	rec := got.(Record)
+	enum := rec.Fields[0].Type.(Enum)
+	fixed := rec.Fields[1].Type.(Fixed)
+	require.Equal(t, "com.example", enum.Namespace)
+	require.Equal(t, "com.example", fixed.Namespace)
+}
+
+func TestField_DefaultAndOrderRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		field *Field
+	}{
+		{
+			name:  "default string",
+			field: &Field{Name: "x", Type: String{}, Default: "hello"},
+		},
+		{
+			name:  "default null",
+			field: &Field{Name: "x", Type: Union{Types: []Schema{Null{}, String{}}}, Default: nil},
+		},
+		{
+			name:  "order descending",
+			field: &Field{Name: "x", Type: Long{}, Order: OrderDescending},
+		},
+		{
+			name:  "order ignore with default",
+			field: &Field{Name: "x", Type: Boolean{}, Default: true, Order: OrderIgnore},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			schema := Record{Name: "R", Fields: []*Field{tc.field}}
+			data, err := json.Marshal(schema)
+			require.NoError(t, err)
+
+			got, err := ParseJSON(data)
+			require.NoError(t, err)
+			rec := got.(Record)
+			require.Equal(t, tc.field.Name, rec.Fields[0].Name)
+			require.Equal(t, tc.field.Order, rec.Fields[0].Order)
+			require.Equal(t, tc.field.Default, rec.Fields[0].Default)
+		})
+	}
 }

--- a/schema_json_test.go
+++ b/schema_json_test.go
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avro
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchema_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		schema Schema
+		want   string
+	}{
+		{name: "null", schema: Null{}, want: `"null"`},
+		{name: "boolean", schema: Boolean{}, want: `"boolean"`},
+		{name: "int", schema: Int{}, want: `"int"`},
+		{name: "long", schema: Long{}, want: `"long"`},
+		{name: "float", schema: Float{}, want: `"float"`},
+		{name: "double", schema: Double{}, want: `"double"`},
+		{name: "bytes", schema: Bytes{}, want: `"bytes"`},
+		{name: "string", schema: String{}, want: `"string"`},
+		{
+			name:   "ref unqualified",
+			schema: Ref{Name: "Foo"},
+			want:   `"Foo"`,
+		},
+		{
+			name:   "ref qualified",
+			schema: Ref{Name: "Foo", Namespace: "com.example"},
+			want:   `"com.example.Foo"`,
+		},
+		{
+			name: "record",
+			schema: Record{
+				Name:      "User",
+				Namespace: "com.example",
+				Fields: []*Field{
+					{Name: "id", Type: Long{}},
+					{Name: "name", Type: String{}},
+				},
+			},
+			want: `{"type":"record","name":"User","namespace":"com.example","fields":[{"name":"id","type":"long"},{"name":"name","type":"string"}]}`,
+		},
+		{
+			name:   "enum",
+			schema: Enum{Name: "Color", Symbols: []string{"RED", "GREEN", "BLUE"}},
+			want:   `{"type":"enum","name":"Color","symbols":["RED","GREEN","BLUE"]}`,
+		},
+		{
+			name:   "array",
+			schema: Array{Items: Long{}},
+			want:   `{"type":"array","items":"long"}`,
+		},
+		{
+			name:   "map",
+			schema: Map{Values: String{}},
+			want:   `{"type":"map","values":"string"}`,
+		},
+		{
+			name:   "union",
+			schema: Union{Types: []Schema{Null{}, String{}}},
+			want:   `["null","string"]`,
+		},
+		{
+			name:   "fixed",
+			schema: Fixed{Name: "MD5", Size: 16},
+			want:   `{"type":"fixed","name":"MD5","size":16}`,
+		},
+		{
+			name:   "decimal over bytes",
+			schema: Decimal{Precision: 9, Scale: 2, Underlying: Bytes{}},
+			want:   `{"type":"bytes","logicalType":"decimal","precision":9,"scale":2}`,
+		},
+		{
+			name:   "decimal over fixed",
+			schema: Decimal{Precision: 9, Scale: 2, Underlying: Fixed{Name: "Dec", Size: 8}},
+			want:   `{"type":"fixed","logicalType":"decimal","name":"Dec","size":8,"precision":9,"scale":2}`,
+		},
+		{name: "uuid", schema: UUID{}, want: `{"type":"string","logicalType":"uuid"}`},
+		{name: "date", schema: Date{}, want: `{"type":"int","logicalType":"date"}`},
+		{name: "time-millis", schema: TimeMillis{}, want: `{"type":"int","logicalType":"time-millis"}`},
+		{name: "time-micros", schema: TimeMicros{}, want: `{"type":"long","logicalType":"time-micros"}`},
+		{name: "timestamp-millis", schema: TimestampMillis{}, want: `{"type":"long","logicalType":"timestamp-millis"}`},
+		{name: "timestamp-micros", schema: TimestampMicros{}, want: `{"type":"long","logicalType":"timestamp-micros"}`},
+		{name: "timestamp-nanos", schema: TimestampNanos{}, want: `{"type":"long","logicalType":"timestamp-nanos"}`},
+		{name: "local-timestamp-millis", schema: LocalTimestampMillis{}, want: `{"type":"long","logicalType":"local-timestamp-millis"}`},
+		{name: "local-timestamp-micros", schema: LocalTimestampMicros{}, want: `{"type":"long","logicalType":"local-timestamp-micros"}`},
+		{name: "local-timestamp-nanos", schema: LocalTimestampNanos{}, want: `{"type":"long","logicalType":"local-timestamp-nanos"}`},
+		{name: "duration", schema: Duration{}, want: `{"type":"fixed","name":"duration","size":12,"logicalType":"duration"}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.schema)
+			require.NoError(t, err)
+			require.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+func TestParseJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		json string
+		want Schema
+	}{
+		{name: "null", json: `"null"`, want: Null{}},
+		{name: "string", json: `"string"`, want: String{}},
+		{name: "ref qualified", json: `"com.example.Foo"`, want: Ref{Namespace: "com.example", Name: "Foo"}},
+		{name: "ref unqualified", json: `"Foo"`, want: Ref{Name: "Foo"}},
+		{
+			name: "record",
+			json: `{"type":"record","name":"User","fields":[{"name":"id","type":"long"}]}`,
+			want: Record{
+				Name:   "User",
+				Fields: []*Field{{Name: "id", Type: Long{}}},
+			},
+		},
+		{
+			name: "enum",
+			json: `{"type":"enum","name":"Color","symbols":["RED","GREEN"]}`,
+			want: Enum{Name: "Color", Symbols: []string{"RED", "GREEN"}},
+		},
+		{name: "array", json: `{"type":"array","items":"long"}`, want: Array{Items: Long{}}},
+		{name: "map", json: `{"type":"map","values":"string"}`, want: Map{Values: String{}}},
+		{name: "union", json: `["null","string"]`, want: Union{Types: []Schema{Null{}, String{}}}},
+		{name: "fixed", json: `{"type":"fixed","name":"MD5","size":16}`, want: Fixed{Name: "MD5", Size: 16}},
+		{
+			name: "decimal over bytes",
+			json: `{"type":"bytes","logicalType":"decimal","precision":9,"scale":2}`,
+			want: Decimal{Precision: 9, Scale: 2, Underlying: Bytes{}},
+		},
+		{
+			name: "decimal over fixed",
+			json: `{"type":"fixed","logicalType":"decimal","name":"Dec","size":8,"precision":9,"scale":2}`,
+			want: Decimal{Precision: 9, Scale: 2, Underlying: Fixed{Name: "Dec", Size: 8}},
+		},
+		{name: "uuid", json: `{"type":"string","logicalType":"uuid"}`, want: UUID{}},
+		{name: "date", json: `{"type":"int","logicalType":"date"}`, want: Date{}},
+		{name: "duration", json: `{"type":"fixed","name":"duration","size":12,"logicalType":"duration"}`, want: Duration{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseJSON([]byte(tc.json))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSchemaJSON_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		schema Schema
+	}{
+		{name: "null", schema: Null{}},
+		{name: "boolean", schema: Boolean{}},
+		{name: "int", schema: Int{}},
+		{name: "long", schema: Long{}},
+		{name: "float", schema: Float{}},
+		{name: "double", schema: Double{}},
+		{name: "bytes", schema: Bytes{}},
+		{name: "string", schema: String{}},
+		{name: "ref qualified", schema: Ref{Namespace: "com.example", Name: "Foo"}},
+		{
+			name: "record with nested types",
+			schema: Record{
+				Name:      "User",
+				Namespace: "com.example",
+				Fields: []*Field{
+					{Name: "id", Type: Long{}},
+					{Name: "tags", Type: Array{Items: String{}}},
+					{Name: "email", Type: Union{Types: []Schema{Null{}, String{}}}},
+					{Name: "ref", Type: Ref{Name: "Other", Namespace: "com.example"}},
+				},
+			},
+		},
+		{
+			name: "enum with default",
+			schema: Enum{
+				Name:    "Color",
+				Symbols: []string{"RED", "GREEN", "BLUE"},
+				Default: "RED",
+			},
+		},
+		{name: "array of long", schema: Array{Items: Long{}}},
+		{name: "map of string", schema: Map{Values: String{}}},
+		{name: "union", schema: Union{Types: []Schema{Null{}, Long{}, String{}}}},
+		{name: "fixed", schema: Fixed{Name: "MD5", Namespace: "com.example", Size: 16}},
+		{name: "decimal over bytes", schema: Decimal{Precision: 9, Scale: 2, Underlying: Bytes{}}},
+		{
+			name: "decimal over fixed",
+			schema: Decimal{
+				Precision:  20,
+				Scale:      4,
+				Underlying: Fixed{Name: "Dec", Namespace: "com.example", Size: 12},
+			},
+		},
+		{name: "uuid", schema: UUID{}},
+		{name: "date", schema: Date{}},
+		{name: "time-millis", schema: TimeMillis{}},
+		{name: "time-micros", schema: TimeMicros{}},
+		{name: "timestamp-millis", schema: TimestampMillis{}},
+		{name: "timestamp-micros", schema: TimestampMicros{}},
+		{name: "timestamp-nanos", schema: TimestampNanos{}},
+		{name: "local-timestamp-millis", schema: LocalTimestampMillis{}},
+		{name: "local-timestamp-micros", schema: LocalTimestampMicros{}},
+		{name: "local-timestamp-nanos", schema: LocalTimestampNanos{}},
+		{name: "duration", schema: Duration{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tc.schema)
+			require.NoError(t, err)
+
+			got, err := ParseJSON(data)
+			require.NoError(t, err)
+			require.Equal(t, tc.schema, got)
+		})
+	}
+}
+
+func TestParseJSON_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing record name", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseJSON([]byte(`{"type":"record","fields":[]}`))
+		var got MissingFieldError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "record", got.Type)
+		require.Equal(t, "name", got.Field)
+	})
+
+	t.Run("missing record fields", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseJSON([]byte(`{"type":"record","name":"R"}`))
+		var got MissingFieldError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "fields", got.Field)
+	})
+
+	t.Run("unknown logical type", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseJSON([]byte(`{"type":"int","logicalType":"bogus"}`))
+		var got UnknownLogicalTypeError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "bogus", got.LogicalType)
+	})
+
+	t.Run("missing fixed size", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseJSON([]byte(`{"type":"fixed","name":"F"}`))
+		var got MissingFieldError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, "size", got.Field)
+	})
+}

--- a/schema_json_test.go
+++ b/schema_json_test.go
@@ -95,7 +95,12 @@ func TestSchema_MarshalJSON(t *testing.T) {
 		{name: "local-timestamp-millis", schema: LocalTimestampMillis{}, want: `{"type":"long","logicalType":"local-timestamp-millis"}`},
 		{name: "local-timestamp-micros", schema: LocalTimestampMicros{}, want: `{"type":"long","logicalType":"local-timestamp-micros"}`},
 		{name: "local-timestamp-nanos", schema: LocalTimestampNanos{}, want: `{"type":"long","logicalType":"local-timestamp-nanos"}`},
-		{name: "duration", schema: Duration{}, want: `{"type":"fixed","name":"duration","size":12,"logicalType":"duration"}`},
+		{name: "duration default name", schema: Duration{}, want: `{"type":"fixed","name":"duration","size":12,"logicalType":"duration"}`},
+		{
+			name:   "duration custom name",
+			schema: Duration{Underlying: Fixed{Name: "Elapsed", Namespace: "com.example", Size: 12}},
+			want:   `{"type":"fixed","logicalType":"duration","name":"Elapsed","namespace":"com.example","size":12}`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -149,7 +154,11 @@ func TestParseJSON(t *testing.T) {
 		},
 		{name: "uuid", json: `{"type":"string","logicalType":"uuid"}`, want: UUID{}},
 		{name: "date", json: `{"type":"int","logicalType":"date"}`, want: Date{}},
-		{name: "duration", json: `{"type":"fixed","name":"duration","size":12,"logicalType":"duration"}`, want: Duration{}},
+		{
+			name: "duration",
+			json: `{"type":"fixed","name":"duration","size":12,"logicalType":"duration"}`,
+			want: Duration{Underlying: Fixed{Name: "duration", Size: 12}},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -222,7 +231,14 @@ func TestSchemaJSON_RoundTrip(t *testing.T) {
 		{name: "local-timestamp-millis", schema: LocalTimestampMillis{}},
 		{name: "local-timestamp-micros", schema: LocalTimestampMicros{}},
 		{name: "local-timestamp-nanos", schema: LocalTimestampNanos{}},
-		{name: "duration", schema: Duration{}},
+		{
+			name:   "duration default name",
+			schema: Duration{Underlying: Fixed{Name: "duration", Size: 12}},
+		},
+		{
+			name:   "duration custom name",
+			schema: Duration{Underlying: Fixed{Name: "Elapsed", Namespace: "com.example", Size: 12}},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avro
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaInterface(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		schema Schema
+	}{
+		{name: "null", schema: Null{}},
+		{name: "boolean", schema: Boolean{}},
+		{name: "int", schema: Int{}},
+		{name: "long", schema: Long{}},
+		{name: "float", schema: Float{}},
+		{name: "double", schema: Double{}},
+		{name: "bytes", schema: Bytes{}},
+		{name: "string", schema: String{}},
+		{name: "ref", schema: Ref{Name: "Foo", Namespace: "com.example"}},
+		{name: "record", schema: Record{Name: "R", Fields: []*Field{{Name: "f", Type: Int{}}}}},
+		{name: "enum", schema: Enum{Name: "E", Symbols: []string{"A", "B"}}},
+		{name: "array", schema: Array{Items: Long{}}},
+		{name: "map", schema: Map{Values: String{}}},
+		{name: "union", schema: Union{Types: []Schema{Null{}, Int{}}}},
+		{name: "fixed", schema: Fixed{Name: "F", Size: 4}},
+		{name: "decimal over bytes", schema: Decimal{Precision: 9, Scale: 2, Underlying: Bytes{}}},
+		{name: "uuid", schema: UUID{}},
+		{name: "date", schema: Date{}},
+		{name: "time millis", schema: TimeMillis{}},
+		{name: "time micros", schema: TimeMicros{}},
+		{name: "timestamp millis", schema: TimestampMillis{}},
+		{name: "timestamp micros", schema: TimestampMicros{}},
+		{name: "timestamp nanos", schema: TimestampNanos{}},
+		{name: "local timestamp millis", schema: LocalTimestampMillis{}},
+		{name: "local timestamp micros", schema: LocalTimestampMicros{}},
+		{name: "local timestamp nanos", schema: LocalTimestampNanos{}},
+		{name: "duration", schema: Duration{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.NotNil(t, tc.schema)
+		})
+	}
+}
+
+func TestRecordFields(t *testing.T) {
+	t.Parallel()
+
+	r := Record{
+		Name:      "User",
+		Namespace: "com.example",
+		Fields: []*Field{
+			{Name: "id", Type: Long{}, Order: OrderAscending},
+			{Name: "email", Type: Union{Types: []Schema{Null{}, String{}}}, Default: nil},
+			{Name: "tags", Type: Array{Items: String{}}, Default: []any{}},
+		},
+	}
+
+	require.Equal(t, "User", r.Name)
+	require.Len(t, r.Fields, 3)
+	require.Equal(t, OrderAscending, r.Fields[0].Order)
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -64,7 +64,7 @@ func TestRecordFields(t *testing.T) {
 		Fields: []*Field{
 			{Name: "id", Type: Long{}, Order: OrderAscending},
 			{Name: "email", Type: Union{Types: []Schema{Null{}, String{}}}, HasDefault: true, Default: nil},
-			{Name: "tags", Type: Array{Items: String{}}, Default: []any{}},
+			{Name: "tags", Type: Array{Items: String{}}, HasDefault: true, Default: []any{}},
 		},
 	}
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -63,7 +63,7 @@ func TestRecordFields(t *testing.T) {
 		Namespace: "com.example",
 		Fields: []*Field{
 			{Name: "id", Type: Long{}, Order: OrderAscending},
-			{Name: "email", Type: Union{Types: []Schema{Null{}, String{}}}, Default: nil},
+			{Name: "email", Type: Union{Types: []Schema{Null{}, String{}}}, HasDefault: true, Default: nil},
 			{Name: "tags", Type: Array{Items: String{}}, Default: []any{}},
 		},
 	}


### PR DESCRIPTION
## Summary

- Adds an `avro.Schema` interface and concrete types (primitives, composites, `Ref`, and 12 distinct logical-type schemas) in the top-level package; this becomes the substrate for future binary/JSON codecs.
- Adds a new `github.com/z5labs/avro-go/generic` package with `Value` types and an `Encoder`/`Decoder` driven by `avro.Schema`. Schemas are validated once at `New*` time and the resulting compiled plan is reused across calls; codec is concurrent-safe given a per-call writer/reader.
- Covers every rejection case listed in the issue (schema-time and runtime), including recursive references via late-bound entries.

Closes #91

## Test plan

- [x] `go test -race -cover ./...` passes (avro 100%, generic 79.8%)
- [x] `go vet ./...` clean
- [x] Round-trip table covers every schema kind including all 12 logicals + a recursive `Node` record
- [x] `ExampleEncoder`, `ExampleDecoder`, `ExampleEncoder_reuse` pass with `// Output:` directives
- [x] Dedicated rejection tests for each documented constructor-time and runtime error

🤖 Generated with [Claude Code](https://claude.com/claude-code)