### PR TITLE
story(issue-108): stream a top-level array without materialising it

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,57 @@ err := avro.UnmarshalBinary(bytes.NewReader(data), &msg)
 
 `BinaryReader` mirrors `BinaryWriter` with corresponding `Read*` methods.
 
+### Streaming Arrays
+
+An Avro `array` is encoded as a series of blocks — a `long` item count followed by that many items, terminated by a zero count — so an array whose encoding is far larger than memory can be read and written an item at a time. `ArrayReader` and `ArrayWriter` own that block framing; neither holds more than a single item.
+
+`ArrayReader.Next` decodes into a destination you supply, so reusing one value across the whole array or keeping every item is your choice:
+
+```go
+r := avro.NewArrayReader(avro.NewBinaryReader(in))
+
+var msg Message
+for {
+    ok, err := r.Next(&msg)
+    if err != nil {
+        return err
+    }
+    if !ok {
+        break
+    }
+    // use msg before the next call overwrites it
+}
+```
+
+`WriteArray` writes items incrementally and terminates the array for you:
+
+```go
+err := avro.WriteArray(avro.NewBinaryWriter(out), func(w *avro.ArrayWriter) error {
+    for _, msg := range messages {
+        if err := w.Write(msg); err != nil {
+            return err
+        }
+    }
+    return nil
+})
+```
+
+Use `NewArrayWriter` directly when the array outlives a single function, but note that an array is only complete once its terminating block is written: an `ArrayWriter` that is never `Close`d produces a truncated array, which `ArrayReader` reports as `ErrTruncatedArray` rather than a short read.
+
+By default each item is written straight through as its own block, buffering nothing. `WithSizedBlocks(n)` instead batches items into blocks that record their encoded size, bounding the buffer at `n` bytes plus one item:
+
+```go
+w := avro.NewArrayWriter(avro.NewBinaryWriter(out), avro.WithSizedBlocks(64<<10))
+```
+
+A sized block can be discarded without decoding any of its items, which is what `ArrayReader.SkipBlock` is for. Because emitting sizes is optional for a writer, `SkipBlock` reports which path it took:
+
+| Result | Meaning |
+|--------|---------|
+| `SkipSized` | The block declared its size and was discarded straight from the reader; no item was decoded |
+| `SkipUnsized` | The block declared no size, so nothing was consumed — drain it with `Next` instead |
+| `SkipNone` | The array's terminating block has been reached |
+
 ### Single-Object Encoding
 
 The [Avro single-object encoding](https://avro.apache.org/docs/current/specification/#single-object-encoding) prepends a 2-byte magic header and an 8-byte schema fingerprint to the binary payload, allowing readers to identify the schema at runtime.

--- a/array.go
+++ b/array.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avro
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math"
+)
+
+var (
+	// ErrTruncatedArray is returned when a stream ends before an array's
+	// terminating zero-count block. It is what an ArrayWriter that was never
+	// closed leaves behind, so callers can distinguish a truncated array from
+	// a genuinely empty one.
+	ErrTruncatedArray = errors.New("avro: truncated array")
+
+	// ErrBlockSizeMismatch is returned when the items of a sized block do not
+	// consume exactly the number of bytes the block declared.
+	ErrBlockSizeMismatch = errors.New("avro: array block size mismatch")
+
+	// ErrArrayWriterClosed is returned by ArrayWriter.Write after the writer
+	// has been closed.
+	ErrArrayWriterClosed = errors.New("avro: array writer closed")
+)
+
+// Skip reports how [ArrayReader.SkipBlock] handled the current block.
+type Skip int
+
+const (
+	// SkipNone reports that no block remained to skip because the array's
+	// terminating zero-count block has been reached.
+	SkipNone Skip = iota
+
+	// SkipSized reports that the current block declared its encoded size in
+	// bytes and so was discarded without decoding any item.
+	SkipSized
+
+	// SkipUnsized reports that the current block did not declare its encoded
+	// size. Item boundaries inside such a block can only be found by decoding,
+	// so SkipBlock consumed nothing and the caller must drain the block with
+	// [ArrayReader.Next] instead.
+	SkipUnsized
+)
+
+func (s Skip) String() string {
+	switch s {
+	case SkipNone:
+		return "none"
+	case SkipSized:
+		return "sized"
+	case SkipUnsized:
+		return "unsized"
+	}
+	return "unknown"
+}
+
+// ArrayReader decodes an Avro array one item at a time.
+//
+// An Avro array is encoded as a series of blocks, each a long item count
+// followed by that many items, terminated by a block whose count is zero. A
+// negative count is the absolute item count and is followed by a long giving
+// the block's encoded size in bytes; see [ArrayReader.SkipBlock].
+//
+// ArrayReader holds no item state of its own, so memory use is a function of
+// the destination passed to [ArrayReader.Next] rather than of the array's
+// length.
+type ArrayReader struct {
+	r *BinaryReader
+
+	remaining int64 // items left to decode in the current block
+	blockEnd  int64 // reader offset at which the current block ends; only valid when sized
+	sized     bool  // whether the current block declared its encoded size
+	done      bool  // whether the terminating zero-count block has been read
+	err       error // sticky error
+}
+
+// NewArrayReader returns an ArrayReader that decodes an array from r.
+func NewArrayReader(r *BinaryReader) *ArrayReader {
+	return &ArrayReader{r: r}
+}
+
+// Next decodes the next item into v. It reports false at the array's
+// terminating zero-count block, and keeps reporting false thereafter.
+//
+// Passing the same v on every call reuses a single destination for the whole
+// array; passing a fresh v each time keeps every item. That choice is the
+// caller's.
+//
+// Once Next returns an error, every later call to Next or
+// [ArrayReader.SkipBlock] returns that same error.
+func (a *ArrayReader) Next(v BinaryUnmarshaler) (bool, error) {
+	if a.err != nil {
+		return false, a.err
+	}
+	if a.done {
+		return false, nil
+	}
+	if a.remaining == 0 {
+		ok, err := a.nextBlock()
+		if err != nil || !ok {
+			return false, err
+		}
+	}
+
+	if err := v.UnmarshalAvroBinary(a.r); err != nil {
+		return false, a.fail(err)
+	}
+	a.remaining--
+
+	if a.remaining == 0 && a.sized && a.r.Offset() != a.blockEnd {
+		return false, a.fail(a.r.wrapErr(ErrBlockSizeMismatch))
+	}
+	return true, nil
+}
+
+// SkipBlock discards the remainder of the current block without decoding it
+// and reports which path it took.
+//
+// It returns [SkipSized] when the block declared its encoded size, in which
+// case the remaining bytes are discarded straight from the underlying reader
+// and no item is decoded. It returns [SkipUnsized] when the block declared no
+// size: nothing is consumed, because finding the block's end would mean
+// decoding every remaining item, which is no cheaper than draining the block
+// with [ArrayReader.Next]. It returns [SkipNone] once the array's terminating
+// zero-count block has been reached.
+func (a *ArrayReader) SkipBlock() (Skip, error) {
+	if a.err != nil {
+		return SkipNone, a.err
+	}
+	if a.done {
+		return SkipNone, nil
+	}
+	if a.remaining == 0 {
+		ok, err := a.nextBlock()
+		if err != nil || !ok {
+			return SkipNone, err
+		}
+	}
+	if !a.sized {
+		return SkipUnsized, nil
+	}
+
+	switch n := a.blockEnd - a.r.Offset(); {
+	case n < 0:
+		return SkipNone, a.fail(a.r.wrapErr(ErrBlockSizeMismatch))
+	case n > 0:
+		if err := a.r.discard(n); err != nil {
+			return SkipNone, a.fail(err)
+		}
+	}
+	a.remaining = 0
+	return SkipSized, nil
+}
+
+// nextBlock reads the header of the next block. It reports false once the
+// array's terminating zero-count block has been read.
+func (a *ArrayReader) nextBlock() (bool, error) {
+	start := a.r.Offset()
+	count, err := a.r.ReadLong()
+	if err != nil {
+		// A clean EOF before any byte of the count is an array that was never
+		// terminated; anywhere else it is a stream cut mid-value.
+		if a.r.Offset() == start && isEOF(err) {
+			return false, a.fail(a.r.wrapErr(ErrTruncatedArray))
+		}
+		return false, a.fail(unexpectedEOF(err))
+	}
+	if count == 0 {
+		a.done = true
+		return false, nil
+	}
+
+	a.sized = count < 0
+	if a.sized {
+		if count == math.MinInt64 {
+			return false, a.fail(a.r.wrapErr(ErrOverflow))
+		}
+		count = -count
+
+		size, err := a.r.ReadLong()
+		if err != nil {
+			return false, a.fail(unexpectedEOF(err))
+		}
+		if size < 0 {
+			return false, a.fail(a.r.wrapErr(ErrNegativeLength))
+		}
+		a.blockEnd = a.r.Offset() + size
+		if a.blockEnd < 0 {
+			return false, a.fail(a.r.wrapErr(ErrOverflow))
+		}
+	}
+
+	a.remaining = count
+	return true, nil
+}
+
+func (a *ArrayReader) fail(err error) error {
+	a.err = err
+	return err
+}
+
+func isEOF(err error) bool {
+	var rerr *BinaryReaderError
+	return errors.As(err, &rerr) && errors.Is(rerr.Err, io.EOF)
+}
+
+// unexpectedEOF rewrites a clean io.EOF into io.ErrUnexpectedEOF, preserving
+// the offset it was reported at. Every value an ArrayReader reads for itself is
+// required by the array framing, so reaching EOF while reading one is a short
+// read rather than a clean end of input.
+func unexpectedEOF(err error) error {
+	var rerr *BinaryReaderError
+	if errors.As(err, &rerr) && errors.Is(rerr.Err, io.EOF) {
+		return &BinaryReaderError{Offset: rerr.Offset, Err: io.ErrUnexpectedEOF}
+	}
+	return err
+}
+
+// DefaultBlockBufferSize is the buffer size [WithSizedBlocks] uses when it is
+// given a non-positive size.
+const DefaultBlockBufferSize = 64 << 10
+
+type arrayWriterOptions struct {
+	sized      bool
+	bufferSize int
+}
+
+// ArrayWriterOption configures an [ArrayWriter].
+type ArrayWriterOption func(*arrayWriterOptions)
+
+// WithSizedBlocks makes an [ArrayWriter] emit sized blocks: each block is
+// prefixed with its negated item count and its encoded size in bytes, which
+// lets a reader discard the whole block with [ArrayReader.SkipBlock] instead of
+// decoding it.
+//
+// A block's size is only known once the block has been encoded, so this buffers
+// items. The buffer is flushed as soon as it reaches bufferSize, and therefore
+// holds at most bufferSize plus the encoding of a single item. A non-positive
+// bufferSize selects [DefaultBlockBufferSize].
+func WithSizedBlocks(bufferSize int) ArrayWriterOption {
+	return func(o *arrayWriterOptions) {
+		o.sized = true
+		o.bufferSize = bufferSize
+	}
+}
+
+// ArrayWriter encodes an Avro array one item at a time.
+//
+// By default it emits unsized blocks and buffers nothing: each item is written
+// straight through as its own block, costing one extra byte per item. Pass
+// [WithSizedBlocks] to batch items into sized blocks instead, trading a bounded
+// buffer for fewer count prefixes and a stream a reader can skip through.
+//
+// An array is terminated by a zero-count block, so an ArrayWriter that is never
+// closed produces a truncated array rather than a complete one missing a flush.
+// [ArrayWriter.Close] must be called, and its error checked; reading such a
+// stream back fails with [ErrTruncatedArray]. Use [WriteArray] to have the close
+// handled for you.
+type ArrayWriter struct {
+	w *BinaryWriter
+
+	buf   *bytes.Buffer // pending block; nil when blocks are unsized
+	bufw  *BinaryWriter // writes into buf
+	limit int           // buffered byte count at which the block is flushed
+
+	count  int64 // items buffered in the pending block
+	closed bool
+	err    error // sticky error
+}
+
+// NewArrayWriter returns an ArrayWriter that encodes an array to w.
+func NewArrayWriter(w *BinaryWriter, opts ...ArrayWriterOption) *ArrayWriter {
+	o := arrayWriterOptions{bufferSize: DefaultBlockBufferSize}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	a := &ArrayWriter{w: w}
+	if o.sized {
+		if o.bufferSize <= 0 {
+			o.bufferSize = DefaultBlockBufferSize
+		}
+		a.limit = o.bufferSize
+		a.buf = bytes.NewBuffer(make([]byte, 0, o.bufferSize))
+		a.bufw = NewBinaryWriter(a.buf)
+	}
+	return a
+}
+
+// Write encodes v as the next item of the array. With sized blocks the item is
+// buffered and only reaches the underlying writer when the block is flushed.
+//
+// Once Write returns an error, every later call to Write or
+// [ArrayWriter.Close] returns that same error.
+func (a *ArrayWriter) Write(v BinaryMarshaler) error {
+	if a.err != nil {
+		return a.err
+	}
+	if a.closed {
+		return ErrArrayWriterClosed
+	}
+
+	if a.buf == nil {
+		if err := a.w.WriteLong(1); err != nil {
+			return a.fail(err)
+		}
+		if err := v.MarshalAvroBinary(a.w); err != nil {
+			return a.fail(err)
+		}
+		return nil
+	}
+
+	if err := v.MarshalAvroBinary(a.bufw); err != nil {
+		return a.fail(err)
+	}
+	a.count++
+	if a.buf.Len() >= a.limit {
+		return a.flush()
+	}
+	return nil
+}
+
+// Close flushes any pending block and writes the array's terminating
+// zero-count block. Closing an already closed ArrayWriter is a no-op.
+func (a *ArrayWriter) Close() error {
+	if a.err != nil {
+		return a.err
+	}
+	if a.closed {
+		return nil
+	}
+	if a.buf != nil {
+		if err := a.flush(); err != nil {
+			return err
+		}
+	}
+	if err := a.w.WriteLong(0); err != nil {
+		return a.fail(err)
+	}
+	a.closed = true
+	return nil
+}
+
+// flush writes the pending block, if any, as a sized block.
+func (a *ArrayWriter) flush() error {
+	if a.count == 0 {
+		return nil
+	}
+	if err := a.w.WriteLong(-a.count); err != nil {
+		return a.fail(err)
+	}
+	if err := a.w.WriteLong(int64(a.buf.Len())); err != nil {
+		return a.fail(err)
+	}
+	if err := a.w.WriteFixed(a.buf.Bytes()); err != nil {
+		return a.fail(err)
+	}
+	a.count = 0
+	a.buf.Reset()
+	return nil
+}
+
+func (a *ArrayWriter) fail(err error) error {
+	a.err = err
+	return err
+}
+
+// WriteArray encodes an Avro array to w, calling f with the [ArrayWriter] to
+// write items to. It closes the writer, terminating the array, once f returns
+// without error.
+//
+// If f returns an error the array is left unterminated, since a partial array
+// should not be presented as a complete one.
+func WriteArray(w *BinaryWriter, f func(*ArrayWriter) error, opts ...ArrayWriterOption) error {
+	a := NewArrayWriter(w, opts...)
+	if err := f(a); err != nil {
+		return err
+	}
+	return a.Close()
+}

--- a/array_example_test.go
+++ b/array_example_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avro
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+)
+
+// reading is an Avro record of a single long, standing in for whatever item
+// type a schema puts inside an array.
+type reading int64
+
+func (r *reading) MarshalAvroBinary(w *BinaryWriter) error {
+	return w.WriteLong(int64(*r))
+}
+
+func (r *reading) UnmarshalAvroBinary(br *BinaryReader) error {
+	v, err := br.ReadLong()
+	if err != nil {
+		return err
+	}
+	*r = reading(v)
+	return nil
+}
+
+func ExampleArrayWriter() {
+	var buf bytes.Buffer
+
+	// Unsized blocks are the default: each item goes straight to the underlying
+	// writer as its own block, so nothing is buffered.
+	w := NewArrayWriter(NewBinaryWriter(&buf))
+	for _, v := range []int64{1, 2, 3} {
+		item := reading(v)
+		if err := w.Write(&item); err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+
+	// Close writes the terminating zero-count block. Without it the array is
+	// truncated, not merely unflushed.
+	if err := w.Close(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Print(hex.Dump(buf.Bytes()))
+
+	// Output: 00000000  02 02 02 04 02 06 00                              |.......|
+}
+
+func ExampleWriteArray() {
+	var buf bytes.Buffer
+
+	// WriteArray closes the array for you once the callback returns. Sized
+	// blocks buffer up to 64 bytes at a time and record each block's encoded
+	// size, which is what lets a reader skip whole blocks.
+	err := WriteArray(NewBinaryWriter(&buf), func(w *ArrayWriter) error {
+		for _, v := range []int64{1, 2, 3} {
+			item := reading(v)
+			if err := w.Write(&item); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, WithSizedBlocks(64))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Print(hex.Dump(buf.Bytes()))
+
+	// Output: 00000000  05 06 02 04 06 00                                 |......|
+}
+
+func ExampleArrayReader() {
+	// Three items in a single unsized block, then the terminator.
+	data := []byte{0x06, 0x02, 0x04, 0x06, 0x00}
+
+	r := NewArrayReader(NewBinaryReader(bytes.NewReader(data)))
+
+	// One destination reused for every item, so memory use is a function of a
+	// single item rather than of the array's length.
+	var item reading
+	for {
+		ok, err := r.Next(&item)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		if !ok {
+			break
+		}
+		fmt.Println(item)
+	}
+
+	// Output:
+	// 1
+	// 2
+	// 3
+}
+
+func ExampleArrayReader_SkipBlock() {
+	// A sized block of three items, then an unsized block of one, then the
+	// terminator.
+	data := []byte{0x05, 0x06, 0x02, 0x04, 0x06, 0x02, 0x08, 0x00}
+
+	r := NewArrayReader(NewBinaryReader(bytes.NewReader(data)))
+
+	var item reading
+	for {
+		skipped, err := r.SkipBlock()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		if skipped == SkipNone {
+			break
+		}
+		if skipped == SkipSized {
+			fmt.Println("discarded a sized block without decoding it")
+			continue
+		}
+
+		// An unsized block carries no byte count, so its end can only be found
+		// by decoding. Drain it instead.
+		fmt.Println("draining an unsized block")
+		for {
+			ok, err := r.Next(&item)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			if !ok {
+				return
+			}
+			fmt.Println(item)
+		}
+	}
+
+	// Output:
+	// discarded a sized block without decoding it
+	// draining an unsized block
+	// 4
+}

--- a/array_test.go
+++ b/array_test.go
@@ -1,0 +1,820 @@
+// Copyright (c) 2026 Z5Labs and Contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package avro
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// arrayItem is a minimal Avro long, used as the item type throughout these
+// tests. It marshals to a single zigzag varint.
+type arrayItem int64
+
+func (v *arrayItem) MarshalAvroBinary(w *BinaryWriter) error {
+	return w.WriteLong(int64(*v))
+}
+
+func (v *arrayItem) UnmarshalAvroBinary(r *BinaryReader) error {
+	l, err := r.ReadLong()
+	if err != nil {
+		return err
+	}
+	*v = arrayItem(l)
+	return nil
+}
+
+// longs encodes each value as a zigzag varint, for building array framing in
+// test fixtures.
+func longs(vals ...int64) []byte {
+	var buf bytes.Buffer
+	w := NewBinaryWriter(&buf)
+	for _, v := range vals {
+		if err := w.WriteLong(v); err != nil {
+			panic(err)
+		}
+	}
+	return buf.Bytes()
+}
+
+func concat(chunks ...[]byte) []byte {
+	var buf bytes.Buffer
+	for _, c := range chunks {
+		buf.Write(c)
+	}
+	return buf.Bytes()
+}
+
+// readAll drains an array, collecting every item it yields.
+func readAll(a *ArrayReader) ([]int64, error) {
+	var items []int64
+	var item arrayItem
+	for {
+		ok, err := a.Next(&item)
+		if err != nil {
+			return items, err
+		}
+		if !ok {
+			return items, nil
+		}
+		items = append(items, int64(item))
+	}
+}
+
+func TestArrayReader(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		data     []byte
+		expected []int64
+	}{
+		{
+			name:     "empty array",
+			data:     []byte{0x00},
+			expected: nil,
+		},
+		{
+			name:     "single unsized block",
+			data:     concat(longs(3), longs(1, 2, 3), longs(0)),
+			expected: []int64{1, 2, 3},
+		},
+		{
+			name:     "multiple unsized blocks",
+			data:     concat(longs(2), longs(1, 2), longs(1), longs(3), longs(0)),
+			expected: []int64{1, 2, 3},
+		},
+		{
+			name: "single sized block",
+			// count -3 means three items, followed by the block's size in bytes.
+			data:     concat(longs(-3), longs(int64(len(longs(1, 2, 3)))), longs(1, 2, 3), longs(0)),
+			expected: []int64{1, 2, 3},
+		},
+		{
+			name: "sized and unsized blocks interleaved",
+			data: concat(
+				longs(-2), longs(int64(len(longs(1, 2)))), longs(1, 2),
+				longs(1), longs(3),
+				longs(-1), longs(int64(len(longs(4)))), longs(4),
+				longs(0),
+			),
+			expected: []int64{1, 2, 3, 4},
+		},
+		{
+			name:     "multi byte items",
+			data:     concat(longs(2), longs(math.MaxInt64, math.MinInt64), longs(0)),
+			expected: []int64{math.MaxInt64, math.MinInt64},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := NewBinaryReader(bytes.NewReader(tc.data))
+			items, err := readAll(NewArrayReader(r))
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, items)
+			require.Equal(t, int64(len(tc.data)), r.Offset())
+		})
+	}
+}
+
+func TestArrayReader_exhausted(t *testing.T) {
+	t.Parallel()
+
+	a := NewArrayReader(NewBinaryReader(bytes.NewReader(concat(longs(1), longs(7), longs(0)))))
+
+	var item arrayItem
+	ok, err := a.Next(&item)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, arrayItem(7), item)
+
+	// Every call past the terminating block keeps reporting the end of the array.
+	for range 3 {
+		ok, err = a.Next(&item)
+		require.NoError(t, err)
+		require.False(t, ok)
+	}
+
+	skipped, err := a.SkipBlock()
+	require.NoError(t, err)
+	require.Equal(t, SkipNone, skipped)
+}
+
+func TestArrayReader_error(t *testing.T) {
+	t.Parallel()
+
+	// A count of math.MinInt64 cannot be negated into an item count.
+	minInt64Count := func() []byte {
+		var buf [binary.MaxVarintLen64]byte
+		n := binary.PutVarint(buf[:], math.MinInt64)
+		return buf[:n]
+	}()
+
+	testCases := []struct {
+		name     string
+		data     []byte
+		expected error
+		items    []int64
+	}{
+		{
+			name:     "empty stream",
+			data:     nil,
+			expected: ErrTruncatedArray,
+		},
+		{
+			name:     "unterminated array",
+			data:     concat(longs(3), longs(1, 2, 3)),
+			expected: ErrTruncatedArray,
+			items:    []int64{1, 2, 3},
+		},
+		{
+			name:     "count cut mid varint",
+			data:     []byte{0x80},
+			expected: io.ErrUnexpectedEOF,
+		},
+		{
+			name:     "block size cut mid varint",
+			data:     concat(longs(-1), []byte{0x80}),
+			expected: io.ErrUnexpectedEOF,
+		},
+		{
+			name:     "missing block size",
+			data:     longs(-1),
+			expected: io.ErrUnexpectedEOF,
+		},
+		{
+			name:     "item cut short",
+			data:     concat(longs(2), longs(1)),
+			expected: io.EOF,
+			items:    []int64{1},
+		},
+		{
+			name:     "negative block size",
+			data:     concat(longs(-1), longs(-1), longs(1), longs(0)),
+			expected: ErrNegativeLength,
+		},
+		{
+			name:     "count overflows on negation",
+			data:     minInt64Count,
+			expected: ErrOverflow,
+		},
+		{
+			name: "block declares more bytes than its items consume",
+			// One item encoded in one byte, but the block claims two.
+			data:     concat(longs(-1), longs(2), longs(1), longs(0)),
+			expected: ErrBlockSizeMismatch,
+		},
+		{
+			name:     "block size overflows the reader offset",
+			data:     concat(longs(-1), longs(math.MaxInt64)),
+			expected: ErrOverflow,
+		},
+		{
+			name:     "count runs past the maximum varint length",
+			data:     bytes.Repeat([]byte{0x80}, binary.MaxVarintLen64),
+			expected: ErrOverflow,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := NewArrayReader(NewBinaryReader(bytes.NewReader(tc.data)))
+			items, err := readAll(a)
+
+			require.ErrorIs(t, err, tc.expected)
+			require.Equal(t, tc.items, items)
+
+			// The error is sticky: it is reported again rather than the reader
+			// silently resuming past it.
+			var item arrayItem
+			ok, again := a.Next(&item)
+			require.False(t, ok)
+			require.Equal(t, err, again)
+
+			_, again = a.SkipBlock()
+			require.Equal(t, err, again)
+		})
+	}
+}
+
+func TestArrayReader_itemError(t *testing.T) {
+	t.Parallel()
+
+	errItem := errors.New("item")
+	failing := binaryUnmarshalerFunc(func(r *BinaryReader) error {
+		return errItem
+	})
+
+	a := NewArrayReader(NewBinaryReader(bytes.NewReader(concat(longs(1), longs(1), longs(0)))))
+
+	ok, err := a.Next(failing)
+	require.False(t, ok)
+	require.ErrorIs(t, err, errItem)
+}
+
+func TestArrayReaderSkipBlock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("discards a sized block without decoding any item", func(t *testing.T) {
+		t.Parallel()
+
+		data := concat(
+			longs(-3), longs(int64(len(longs(1, 2, 3)))), longs(1, 2, 3),
+			longs(1), longs(4),
+			longs(0),
+		)
+		r := NewBinaryReader(bytes.NewReader(data))
+		a := NewArrayReader(r)
+
+		skipped, err := a.SkipBlock()
+		require.NoError(t, err)
+		require.Equal(t, SkipSized, skipped)
+		require.Equal(t, int64(len(data)-len(longs(1))-len(longs(4))-len(longs(0))), r.Offset())
+
+		items, err := readAll(a)
+		require.NoError(t, err)
+		require.Equal(t, []int64{4}, items)
+	})
+
+	t.Run("discards the remainder of a partly decoded sized block", func(t *testing.T) {
+		t.Parallel()
+
+		data := concat(
+			longs(-3), longs(int64(len(longs(1, 2, 3)))), longs(1, 2, 3),
+			longs(1), longs(4),
+			longs(0),
+		)
+		a := NewArrayReader(NewBinaryReader(bytes.NewReader(data)))
+
+		var item arrayItem
+		ok, err := a.Next(&item)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, arrayItem(1), item)
+
+		skipped, err := a.SkipBlock()
+		require.NoError(t, err)
+		require.Equal(t, SkipSized, skipped)
+
+		items, err := readAll(a)
+		require.NoError(t, err)
+		require.Equal(t, []int64{4}, items)
+	})
+
+	t.Run("consumes nothing when the block is unsized", func(t *testing.T) {
+		t.Parallel()
+
+		data := concat(longs(3), longs(1, 2, 3), longs(0))
+		r := NewBinaryReader(bytes.NewReader(data))
+		a := NewArrayReader(r)
+
+		skipped, err := a.SkipBlock()
+		require.NoError(t, err)
+		require.Equal(t, SkipUnsized, skipped)
+
+		// Only the block header was read; the items are still there to drain.
+		require.Equal(t, int64(len(longs(3))), r.Offset())
+
+		items, err := readAll(a)
+		require.NoError(t, err)
+		require.Equal(t, []int64{1, 2, 3}, items)
+	})
+
+	t.Run("reports the unsized path repeatedly", func(t *testing.T) {
+		t.Parallel()
+
+		a := NewArrayReader(NewBinaryReader(bytes.NewReader(concat(longs(1), longs(1), longs(0)))))
+
+		for range 3 {
+			skipped, err := a.SkipBlock()
+			require.NoError(t, err)
+			require.Equal(t, SkipUnsized, skipped)
+		}
+	})
+
+	t.Run("reports no block on an empty array", func(t *testing.T) {
+		t.Parallel()
+
+		a := NewArrayReader(NewBinaryReader(bytes.NewReader(longs(0))))
+
+		skipped, err := a.SkipBlock()
+		require.NoError(t, err)
+		require.Equal(t, SkipNone, skipped)
+	})
+
+	t.Run("errors when the block declares fewer bytes than its items consume", func(t *testing.T) {
+		t.Parallel()
+
+		// Two items, but the block claims to be empty.
+		data := concat(longs(-2), longs(0), longs(1, 2), longs(0))
+		a := NewArrayReader(NewBinaryReader(bytes.NewReader(data)))
+
+		var item arrayItem
+		ok, err := a.Next(&item)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		skipped, err := a.SkipBlock()
+		require.Equal(t, SkipNone, skipped)
+		require.ErrorIs(t, err, ErrBlockSizeMismatch)
+	})
+
+	t.Run("errors when a sized block is cut short", func(t *testing.T) {
+		t.Parallel()
+
+		// The block claims 16 bytes but only three follow.
+		data := concat(longs(-3), longs(16), longs(1, 2, 3))
+		a := NewArrayReader(NewBinaryReader(bytes.NewReader(data)))
+
+		skipped, err := a.SkipBlock()
+		require.Equal(t, SkipNone, skipped)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+}
+
+func TestArrayWriter(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		opts     []ArrayWriterOption
+		items    []int64
+		expected []byte
+	}{
+		{
+			name:     "empty array",
+			items:    nil,
+			expected: []byte{0x00},
+		},
+		{
+			name:  "unsized blocks default to one item per block",
+			items: []int64{1, 2, 3},
+			expected: []byte{
+				0x02, 0x02, // count 1, item 1
+				0x02, 0x04, // count 1, item 2
+				0x02, 0x06, // count 1, item 3
+				0x00, // terminator
+			},
+		},
+		{
+			name:  "sized blocks batch until the buffer fills",
+			opts:  []ArrayWriterOption{WithSizedBlocks(2)},
+			items: []int64{1, 2, 3},
+			expected: []byte{
+				0x03, 0x04, 0x02, 0x04, // count -2, size 2, items 1 and 2
+				0x01, 0x02, 0x06, // count -1, size 1, item 3
+				0x00, // terminator
+			},
+		},
+		{
+			name:  "sized blocks hold every item when the buffer never fills",
+			opts:  []ArrayWriterOption{WithSizedBlocks(1024)},
+			items: []int64{1, 2, 3},
+			expected: []byte{
+				0x05, 0x06, 0x02, 0x04, 0x06, // count -3, size 3, items 1, 2 and 3
+				0x00, // terminator
+			},
+		},
+		{
+			name:     "sized blocks on an empty array write only the terminator",
+			opts:     []ArrayWriterOption{WithSizedBlocks(1024)},
+			items:    nil,
+			expected: []byte{0x00},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			a := NewArrayWriter(NewBinaryWriter(&buf), tc.opts...)
+
+			for _, v := range tc.items {
+				item := arrayItem(v)
+				require.NoError(t, a.Write(&item))
+			}
+			require.NoError(t, a.Close())
+
+			require.Equal(t, tc.expected, buf.Bytes())
+		})
+	}
+}
+
+func TestArrayWriter_singleItemLargerThanBuffer(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	a := NewArrayWriter(NewBinaryWriter(&buf), WithSizedBlocks(1))
+
+	// math.MaxInt64 encodes to ten bytes, well past the one byte buffer, so it
+	// is flushed as a block of its own.
+	item := arrayItem(math.MaxInt64)
+	require.NoError(t, a.Write(&item))
+	require.NoError(t, a.Close())
+
+	expected := concat(longs(-1), longs(int64(len(longs(math.MaxInt64)))), longs(math.MaxInt64), longs(0))
+	require.Equal(t, expected, buf.Bytes())
+}
+
+func TestArrayWriter_close(t *testing.T) {
+	t.Parallel()
+
+	t.Run("is idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		a := NewArrayWriter(NewBinaryWriter(&buf))
+
+		require.NoError(t, a.Close())
+		require.NoError(t, a.Close())
+		require.Equal(t, []byte{0x00}, buf.Bytes())
+	})
+
+	t.Run("rejects writes afterwards", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		a := NewArrayWriter(NewBinaryWriter(&buf))
+		require.NoError(t, a.Close())
+
+		item := arrayItem(1)
+		require.ErrorIs(t, a.Write(&item), ErrArrayWriterClosed)
+		require.Equal(t, []byte{0x00}, buf.Bytes())
+	})
+
+	t.Run("omitting it leaves a detectably truncated array", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		a := NewArrayWriter(NewBinaryWriter(&buf))
+
+		for _, v := range []int64{1, 2, 3} {
+			item := arrayItem(v)
+			require.NoError(t, a.Write(&item))
+		}
+		// Deliberately not closed.
+
+		items, err := readAll(NewArrayReader(NewBinaryReader(bytes.NewReader(buf.Bytes()))))
+		require.ErrorIs(t, err, ErrTruncatedArray)
+		require.Equal(t, []int64{1, 2, 3}, items)
+	})
+}
+
+func TestArrayWriter_error(t *testing.T) {
+	t.Parallel()
+
+	errWrite := errors.New("write")
+
+	for _, tc := range []struct {
+		name string
+		opts []ArrayWriterOption
+	}{
+		{name: "unsized blocks"},
+		{name: "sized blocks", opts: []ArrayWriterOption{WithSizedBlocks(1024)}},
+	} {
+		t.Run("propagates and sticks on a failed item with "+tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			a := NewArrayWriter(NewBinaryWriter(&buf), tc.opts...)
+
+			failing := binaryMarshalerFunc(func(w *BinaryWriter) error {
+				return errWrite
+			})
+
+			require.ErrorIs(t, a.Write(failing), errWrite)
+
+			item := arrayItem(1)
+			require.ErrorIs(t, a.Write(&item), errWrite)
+			require.ErrorIs(t, a.Close(), errWrite)
+		})
+	}
+
+	t.Run("propagates a failed block count on an unsized write", func(t *testing.T) {
+		t.Parallel()
+
+		a := NewArrayWriter(NewBinaryWriter(failAfter(0, errWrite)))
+
+		item := arrayItem(1)
+		require.ErrorIs(t, a.Write(&item), errWrite)
+	})
+
+	// A sized block is flushed as a count, then a size, then the buffered
+	// items, so each of the three can fail on its own.
+	for i, name := range []string{"count", "size", "items"} {
+		t.Run("propagates a failed block "+name+" on close", func(t *testing.T) {
+			t.Parallel()
+
+			a := NewArrayWriter(NewBinaryWriter(failAfter(i, errWrite)), WithSizedBlocks(1024))
+
+			item := arrayItem(1)
+			require.NoError(t, a.Write(&item))
+			require.ErrorIs(t, a.Close(), errWrite)
+		})
+	}
+
+	t.Run("propagates a failed terminator", func(t *testing.T) {
+		t.Parallel()
+
+		out := writerFunc(func(p []byte) (int, error) {
+			return 0, errWrite
+		})
+		a := NewArrayWriter(NewBinaryWriter(out))
+
+		require.ErrorIs(t, a.Close(), errWrite)
+	})
+}
+
+// failAfter returns a writer that accepts n writes and then fails every one
+// thereafter.
+func failAfter(n int, err error) io.Writer {
+	return writerFunc(func(p []byte) (int, error) {
+		if n == 0 {
+			return 0, err
+		}
+		n--
+		return len(p), nil
+	})
+}
+
+func TestWriteArray(t *testing.T) {
+	t.Parallel()
+
+	t.Run("terminates the array", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		err := WriteArray(NewBinaryWriter(&buf), func(a *ArrayWriter) error {
+			for _, v := range []int64{1, 2, 3} {
+				item := arrayItem(v)
+				if err := a.Write(&item); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		require.NoError(t, err)
+
+		items, err := readAll(NewArrayReader(NewBinaryReader(bytes.NewReader(buf.Bytes()))))
+		require.NoError(t, err)
+		require.Equal(t, []int64{1, 2, 3}, items)
+	})
+
+	t.Run("leaves the array unterminated when the callback fails", func(t *testing.T) {
+		t.Parallel()
+
+		errItems := errors.New("items")
+
+		var buf bytes.Buffer
+		err := WriteArray(NewBinaryWriter(&buf), func(a *ArrayWriter) error {
+			item := arrayItem(1)
+			if err := a.Write(&item); err != nil {
+				return err
+			}
+			return errItems
+		})
+		require.ErrorIs(t, err, errItems)
+
+		_, err = readAll(NewArrayReader(NewBinaryReader(bytes.NewReader(buf.Bytes()))))
+		require.ErrorIs(t, err, ErrTruncatedArray)
+	})
+}
+
+func TestArrayRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		opts  []ArrayWriterOption
+		items []int64
+	}{
+		{name: "unsized empty", items: nil},
+		{name: "unsized single item", items: []int64{42}},
+		{name: "unsized many items", items: sequence(1000)},
+		{name: "sized empty", opts: []ArrayWriterOption{WithSizedBlocks(64)}, items: nil},
+		{name: "sized single item", opts: []ArrayWriterOption{WithSizedBlocks(64)}, items: []int64{42}},
+		{name: "sized many small blocks", opts: []ArrayWriterOption{WithSizedBlocks(16)}, items: sequence(1000)},
+		{name: "sized one large block", opts: []ArrayWriterOption{WithSizedBlocks(1 << 20)}, items: sequence(1000)},
+		{name: "sized default buffer", opts: []ArrayWriterOption{WithSizedBlocks(0)}, items: sequence(1000)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			err := WriteArray(NewBinaryWriter(&buf), func(a *ArrayWriter) error {
+				for _, v := range tc.items {
+					item := arrayItem(v)
+					if err := a.Write(&item); err != nil {
+						return err
+					}
+				}
+				return nil
+			}, tc.opts...)
+			require.NoError(t, err)
+
+			items, err := readAll(NewArrayReader(NewBinaryReader(bytes.NewReader(buf.Bytes()))))
+			require.NoError(t, err)
+
+			var expected []int64
+			if len(tc.items) > 0 {
+				expected = tc.items
+			}
+			require.Equal(t, expected, items)
+		})
+	}
+}
+
+func TestArrayRoundTripSkippingSizedBlocks(t *testing.T) {
+	t.Parallel()
+
+	items := sequence(1000)
+
+	var buf bytes.Buffer
+	err := WriteArray(NewBinaryWriter(&buf), func(a *ArrayWriter) error {
+		for _, v := range items {
+			item := arrayItem(v)
+			if err := a.Write(&item); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, WithSizedBlocks(16))
+	require.NoError(t, err)
+
+	// Every block is sized, so the whole array can be discarded without a
+	// single item being decoded.
+	a := NewArrayReader(NewBinaryReader(bytes.NewReader(buf.Bytes())))
+	blocks := 0
+	for {
+		skipped, err := a.SkipBlock()
+		require.NoError(t, err)
+		require.NotEqual(t, SkipUnsized, skipped)
+		if skipped == SkipNone {
+			break
+		}
+		blocks++
+	}
+	require.Greater(t, blocks, 1)
+}
+
+func sequence(n int) []int64 {
+	items := make([]int64, n)
+	for i := range items {
+		items[i] = int64(i)
+	}
+	return items
+}
+
+func TestArrayStreamingAllocations(t *testing.T) {
+	// Not parallel: allocation counts are only meaningful when nothing else in
+	// this test binary is allocating at the same time.
+
+	const (
+		few  = 1_000
+		many = 100_000
+
+		// Every item has the same encoded width so that item count is the only
+		// thing that differs between the two measurements.
+		value = arrayItem(1234)
+	)
+
+	build := func(n int, opts ...ArrayWriterOption) []byte {
+		var buf bytes.Buffer
+		err := WriteArray(NewBinaryWriter(&buf), func(a *ArrayWriter) error {
+			item := value
+			for range n {
+				if err := a.Write(&item); err != nil {
+					return err
+				}
+			}
+			return nil
+		}, opts...)
+		require.NoError(t, err)
+		return buf.Bytes()
+	}
+
+	readAllocs := func(data []byte) float64 {
+		return testing.AllocsPerRun(3, func() {
+			a := NewArrayReader(NewBinaryReader(bytes.NewReader(data)))
+			var item arrayItem
+			for {
+				ok, err := a.Next(&item)
+				if err != nil || !ok {
+					return
+				}
+			}
+		})
+	}
+
+	writeAllocs := func(n int, opts ...ArrayWriterOption) float64 {
+		return testing.AllocsPerRun(3, func() {
+			_ = WriteArray(NewBinaryWriter(io.Discard), func(a *ArrayWriter) error {
+				item := value
+				for range n {
+					if err := a.Write(&item); err != nil {
+						return err
+					}
+				}
+				return nil
+			}, opts...)
+		})
+	}
+
+	t.Run("reading an unsized array", func(t *testing.T) {
+		require.Equal(t, readAllocs(build(few)), readAllocs(build(many)))
+	})
+
+	t.Run("reading a sized array", func(t *testing.T) {
+		opt := WithSizedBlocks(64)
+		require.Equal(t, readAllocs(build(few, opt)), readAllocs(build(many, opt)))
+	})
+
+	t.Run("writing an unsized array", func(t *testing.T) {
+		require.Equal(t, writeAllocs(few), writeAllocs(many))
+	})
+
+	t.Run("writing a sized array", func(t *testing.T) {
+		require.Equal(t, writeAllocs(few, WithSizedBlocks(64)), writeAllocs(many, WithSizedBlocks(64)))
+	})
+}
+
+func TestSkipString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		skip     Skip
+		expected string
+	}{
+		{name: "none", skip: SkipNone, expected: "none"},
+		{name: "sized", skip: SkipSized, expected: "sized"},
+		{name: "unsized", skip: SkipUnsized, expected: "unsized"},
+		{name: "out of range", skip: Skip(42), expected: "unknown"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expected, tc.skip.String())
+		})
+	}
+}

--- a/avro.go
+++ b/avro.go
@@ -27,6 +27,10 @@ func MarshalBinary(w io.Writer, v BinaryMarshaler) error {
 type BinaryWriter struct {
 	out    io.Writer
 	offset int64
+
+	// scratch backs the fixed-size encodings so that they do not escape to the
+	// heap on every write. Its contents never outlive a single method call.
+	scratch [binary.MaxVarintLen64]byte
 }
 
 // NewBinaryWriter returns a BinaryWriter that writes to w.
@@ -63,11 +67,11 @@ func (w *BinaryWriter) wrapErr(err error, bytesWritten int) error {
 
 // WriteBool writes a boolean value to the writer. It writes 1 for true and 0 for false.
 func (w *BinaryWriter) WriteBool(b bool) error {
-	var value byte
+	w.scratch[0] = 0
 	if b {
-		value = 1
+		w.scratch[0] = 1
 	}
-	n, err := w.out.Write([]byte{value})
+	n, err := w.out.Write(w.scratch[:1])
 	if err != nil {
 		return w.wrapErr(err, n)
 	}
@@ -85,9 +89,8 @@ func (w *BinaryWriter) WriteInt(i int32) error {
 
 // WriteLong writes a 64-bit integer to the writer using variable-length zigzag encoding.
 func (w *BinaryWriter) WriteLong(l int64) error {
-	var buf [binary.MaxVarintLen64]byte
-	n := binary.PutVarint(buf[:], l)
-	nw, err := w.out.Write(buf[:n])
+	n := binary.PutVarint(w.scratch[:], l)
+	nw, err := w.out.Write(w.scratch[:n])
 	if err != nil {
 		return w.wrapErr(err, nw)
 	}
@@ -100,9 +103,8 @@ func (w *BinaryWriter) WriteLong(l int64) error {
 
 // WriteFloat writes a 32-bit floating-point number to the writer in little-endian format.
 func (w *BinaryWriter) WriteFloat(f float32) error {
-	var buf [4]byte
-	binary.LittleEndian.PutUint32(buf[:], math.Float32bits(f))
-	nw, err := w.out.Write(buf[:])
+	binary.LittleEndian.PutUint32(w.scratch[:4], math.Float32bits(f))
+	nw, err := w.out.Write(w.scratch[:4])
 	if err != nil {
 		return w.wrapErr(err, nw)
 	}
@@ -115,9 +117,8 @@ func (w *BinaryWriter) WriteFloat(f float32) error {
 
 // WriteDouble writes a 64-bit floating-point number to the writer in little-endian format.
 func (w *BinaryWriter) WriteDouble(d float64) error {
-	var buf [8]byte
-	binary.LittleEndian.PutUint64(buf[:], math.Float64bits(d))
-	nw, err := w.out.Write(buf[:])
+	binary.LittleEndian.PutUint64(w.scratch[:8], math.Float64bits(d))
+	nw, err := w.out.Write(w.scratch[:8])
 	if err != nil {
 		return w.wrapErr(err, nw)
 	}
@@ -187,6 +188,11 @@ func UnmarshalBinary(r io.Reader, v BinaryUnmarshaler) error {
 type BinaryReader struct {
 	in     io.Reader
 	offset int64
+
+	// scratch backs the fixed-size decodings so that they do not escape to the
+	// heap on every read. Its contents never outlive a single method call, and
+	// are never handed to a caller.
+	scratch [8]byte
 }
 
 // NewBinaryReader returns a BinaryReader that reads from r.
@@ -229,13 +235,12 @@ var (
 
 // ReadBool reads a boolean value from the reader. It returns true if the byte is non-zero.
 func (r *BinaryReader) ReadBool() (bool, error) {
-	var buf [1]byte
-	n, err := io.ReadFull(r.in, buf[:])
+	n, err := io.ReadFull(r.in, r.scratch[:1])
 	r.offset += int64(n)
 	if err != nil {
 		return false, r.wrapErr(err)
 	}
-	return buf[0] != 0, nil
+	return r.scratch[0] != 0, nil
 }
 
 // ReadInt reads a 32-bit integer from the reader using variable-length zigzag encoding.
@@ -252,16 +257,15 @@ func (r *BinaryReader) ReadInt() (int32, error) {
 
 // ReadLong reads a 64-bit integer from the reader using variable-length zigzag encoding.
 func (r *BinaryReader) ReadLong() (int64, error) {
-	var buf [1]byte
 	var unsigned uint64
 	var shift uint
 	for i := 0; i < binary.MaxVarintLen64; i++ {
-		n, err := io.ReadFull(r.in, buf[:])
+		n, err := io.ReadFull(r.in, r.scratch[:1])
 		r.offset += int64(n)
 		if err != nil {
 			return 0, r.wrapErr(err)
 		}
-		b := buf[0]
+		b := r.scratch[0]
 		unsigned |= uint64(b&0x7f) << shift
 		if b&0x80 == 0 {
 			return int64(unsigned>>1) ^ -int64(unsigned&1), nil
@@ -273,24 +277,22 @@ func (r *BinaryReader) ReadLong() (int64, error) {
 
 // ReadFloat reads a 32-bit floating-point number from the reader in little-endian format.
 func (r *BinaryReader) ReadFloat() (float32, error) {
-	var buf [4]byte
-	n, err := io.ReadFull(r.in, buf[:])
+	n, err := io.ReadFull(r.in, r.scratch[:4])
 	r.offset += int64(n)
 	if err != nil {
 		return 0, r.wrapErr(err)
 	}
-	return math.Float32frombits(binary.LittleEndian.Uint32(buf[:])), nil
+	return math.Float32frombits(binary.LittleEndian.Uint32(r.scratch[:4])), nil
 }
 
 // ReadDouble reads a 64-bit floating-point number from the reader in little-endian format.
 func (r *BinaryReader) ReadDouble() (float64, error) {
-	var buf [8]byte
-	n, err := io.ReadFull(r.in, buf[:])
+	n, err := io.ReadFull(r.in, r.scratch[:8])
 	r.offset += int64(n)
 	if err != nil {
 		return 0, r.wrapErr(err)
 	}
-	return math.Float64frombits(binary.LittleEndian.Uint64(buf[:])), nil
+	return math.Float64frombits(binary.LittleEndian.Uint64(r.scratch[:8])), nil
 }
 
 // ReadBytes reads a byte array from the reader. It first reads the length as a long, followed by the bytes.
@@ -326,6 +328,19 @@ func (r *BinaryReader) ReadFixed(size int) ([]byte, error) {
 		return nil, r.wrapErr(err)
 	}
 	return buf, nil
+}
+
+// discard advances the reader past n bytes without retaining them.
+func (r *BinaryReader) discard(n int64) error {
+	nr, err := io.CopyN(io.Discard, r.in, n)
+	r.offset += nr
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			err = io.ErrUnexpectedEOF
+		}
+		return r.wrapErr(err)
+	}
+	return nil
 }
 
 // ReadString reads a string from the reader. It first reads the length as a long, followed by the UTF-8 bytes of the string.


### PR DESCRIPTION
Closes #108

Adds `ArrayReader` and `ArrayWriter`, which own Avro's array block framing so a top-level `array<T>` can be read and written an item at a time. Neither holds more than a single item, so memory use is a function of one item rather than of the array's length.

## Reading

```go
r := avro.NewArrayReader(avro.NewBinaryReader(in))

var msg Message
for {
    ok, err := r.Next(&msg)
    if err != nil {
        return err
    }
    if !ok {
        break
    }
    // use msg before the next call overwrites it
}
```

`Next` takes the destination on each call, so reusing one value across the array or keeping every item stays the caller's decision rather than being baked into a signature.

## Writing

```go
err := avro.WriteArray(avro.NewBinaryWriter(out), func(w *avro.ArrayWriter) error {
    for _, msg := range messages {
        if err := w.Write(msg); err != nil {
            return err
        }
    }
    return nil
})
```

Unsized blocks are the default and buffer nothing: each item goes straight through as its own block, costing one byte per item. `WithSizedBlocks(n)` batches into sized blocks instead, with the buffer bounded at `n` bytes plus one item's encoding.

## Two things the issue asked to be precise about

**Skipping is uneven, and the API says so.** `SkipBlock` returns a `Skip` rather than a `bool`, because there are three outcomes and a bool can only carry two:

| Result | Meaning |
|--------|---------|
| `SkipSized` | Block declared its size; discarded via `io.CopyN(io.Discard, …)` with no item decoded |
| `SkipUnsized` | Block declared no size, so **nothing was consumed** — drain it with `Next` instead |
| `SkipNone` | The terminating block has been reached |

On an unsized block `SkipBlock` declines rather than pretending it can skip cheaply. That keeps `ArrayReader` free of any need to know the item type, which is what makes the loop type-independent.

**Failing to close is detectable.** An unterminated array is a truncated array, not a missing flush, so `ArrayReader` distinguishes a clean EOF on a block boundary (`ErrTruncatedArray`) from a stream cut mid-value (`io.ErrUnexpectedEOF`). `WriteArray` handles the close for callers who don't need the writer to outlive a function. There is also `ErrBlockSizeMismatch` for a sized block whose items don't consume exactly what it declared.

## One change outside the issue's scope

`BinaryReader` and `BinaryWriter` now carry reusable scratch buffers for their fixed-size encodings. The stack arrays they used escaped into the `io.Reader`/`io.Writer` interfaces, costing an allocation per varint — reading 10,000 items allocated 20,004 times. It is now flat at 3 regardless of item count. Without this the "peak allocation does not grow with item count" criterion could not be asserted honestly.

## Acceptance criteria

- [x] `ArrayReader` decodes a top-level `array<T>` item by item across multiple blocks without materialising the array
- [x] Handles positive counts, negative counts with a byte-size prefix, an empty array, and a truncated stream — the last erroring rather than short-reading
- [x] `SkipBlock` discards a sized block without decoding any item, and reports which path it took
- [x] `ArrayWriter` writes items incrementally and terminates the array on `Close`
- [x] Unsized blocks are the default and buffer nothing; sized blocks are opt-in and bounded
- [x] Failing to close is detectable rather than silently producing a truncated array
- [x] Round trip in both block modes
- [x] Peak allocation does not grow with item count, asserted rather than assumed

## Verification

- `go test -race -cover ./...` passes; **100% statement coverage on `array.go`**
- `golangci-lint run`: 0 issues
- Allocation flatness asserted with `testing.AllocsPerRun` at 1,000 vs 100,000 items, item width held constant so count is the only variable
- Four runnable examples; README section added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
